### PR TITLE
Fix Ancestry builder to work with current state of datasource

### DIFF
--- a/ancestry-feats-pf2.json
+++ b/ancestry-feats-pf2.json
@@ -1,20 +1,18 @@
 {
     "name": "Pathfinder 2.0 Ancestry feat list",
-    "date": "February 11, 2020",
+    "date": "December 28, 2020",
     " dwarfFeats": [
         {
             "name": "Avenge in Glory",
             "level": "1",
             "traits": [
                 "Dwarf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=964",
             "prereq": "\u2014",
             "benefits": "You honor your ally\u2019s life, gaining temporary Hit Points equal to your level for 1 minute.",
-            "text": [
-                "You honor your ally\u2019s life, gaining temporary Hit Points equal to your level for 1 minute. As long as you have these temporary Hit Points, you gain a +1 circumstance bonus to attack and damage rolls."
-            ]
+            "text": "You honor your ally\u2019s life, gaining temporary Hit Points equal to your level for 1 minute. As long as you have these temporary Hit Points, you gain a +1 circumstance bonus to attack and damage rolls."
         },
         {
             "name": "Clan's Edge",
@@ -25,9 +23,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=965",
             "prereq": "trained in clan daggers",
             "benefits": "By moving your clan dagger with rapid precision, you can protect yourself more effectively.",
-            "text": [
-                "By moving your clan dagger with rapid precision, you can protect yourself more effectively. Make two clan dagger Strikes against different targets. Your multiple attack penalty applies normally to these Strikes. You then use an Interact action to gain the +1 circumstance bonus to your AC from your clan dagger\u2019s parrying trait."
-            ]
+            "text": "By moving your clan dagger with rapid precision, you can protect yourself more effectively. Make two clan dagger Strikes against different targets. Your multiple attack penalty applies normally to these Strikes. You then use an Interact action to gain the +1 circumstance bonus to your AC from your clan dagger\u2019s parrying trait."
+        },
+        {
+            "name": "Dwarven Doughtiness",
+            "level": "1",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1397",
+            "prereq": "\u2014",
+            "benefits": "You are either naturally calm and collected in the face of imminent danger, or you are very good at faking it.",
+            "text": "You are either naturally calm and collected in the face of imminent danger, or you are very good at faking it. At the end of your turn, reduce your frightened condition by 2 instead of 1."
         },
         {
             "name": "Dwarven Lore",
@@ -38,9 +45,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1",
             "prereq": "\u2014",
             "benefits": "You eagerly absorbed the old stories and traditions of your ancestors, your gods, and your people.",
-            "text": [
-                "You eagerly absorbed the old stories and traditions of your ancestors, your gods, and your people, studying in subjects and techniques passed down for generation upon generation. You gain the trained proficiency rank in Crafting and Religion. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Dwarven Lore."
-            ]
+            "text": "You eagerly absorbed the old stories and traditions of your ancestors, your gods, and your people, studying in subjects and techniques passed down for generation upon generation. You gain the trained proficiency rank in Crafting and Religion. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Dwarven Lore.\r\n"
         },
         {
             "name": "Dwarven Weapon Familiarity",
@@ -51,26 +56,30 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=2",
             "prereq": "\u2014",
             "benefits": "Your kin have instilled in you an affinity for hard-hitting weapons, and you prefer these to more elegant arms.",
-            "text": [
-                "Your kin have instilled in you an affinity for hard-hitting weapons, and you prefer these to more elegant arms. You are trained with the battle axe, pick, and warhammer.",
-                " You also gain access to all uncommon dwarf weapons. For the purpose of determining your proficiency, martial dwarf weapons are simple weapons and advanced dwarf weapons are martial weapons."
-            ]
+            "text": "Your kin have instilled in you an affinity for hard-hitting weapons, and you prefer these to more elegant arms. You are trained with the battle axe, pick, and warhammer. You also gain access to all uncommon dwarf weapons. For the purpose of determining your proficiency, martial dwarf weapons are simple weapons and advanced dwarf weapons are martial weapons.\r\n"
+        },
+        {
+            "name": "Eye for Treasure",
+            "level": "1",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1398",
+            "prereq": "\u2014",
+            "benefits": "You know good artisanship when you see it and can wax poetic about crafting techniques and forms.",
+            "text": "You know good artisanship when you see it and can wax poetic about crafting techniques and forms. You become trained in Crafting and gain a +1 circumstance bonus on all Crafting checks made to Recall Knowledge. If you would automatically become trained in Crafting (from your background or class, for example), you instead become trained in a skill of your choice. In addition, you gain the Crafter's Appraisal skill feat, enabling you to identify magic items using the Crafting skill."
         },
         {
             "name": "Forge-Day's Rest",
             "level": "1",
             "traits": [
                 "Dwarf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=966",
             "prereq": "\u2014",
             "benefits": "Your unusual rest cycle allows you to recover faster.",
-            "text": [
-                "Your unusual rest cycle allows you to recover faster. As long as you rest for 12 hours, you gain the effects of the ",
-                " general feat and you can go 20 hours without resting before becoming ",
-                "."
-            ]
+            "text": "Your unusual rest cycle allows you to recover faster. As long as you rest for 12 hours, you gain the effects of the Fast Recovery general feat and you can go 20 hours without resting before becoming fatigued."
         },
         {
             "name": "Rock Runner",
@@ -81,9 +90,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=3",
             "prereq": "\u2014",
             "benefits": "Your innate connection to stone makes you adept at moving across uneven surfaces.",
-            "text": [
-                "Your innate connection to stone makes you adept at moving across uneven surfaces. You can ignore difficult terrain caused by rubble and uneven ground made of stone and earth. In addition, when you use the Acrobatics skill to Balance on narrow surfaces or uneven ground made of stone or earth, you aren\u2019t flat-footed, and when you roll a success at one of these Acrobatics checks, you get a critical success instead."
-            ]
+            "text": "Your innate connection to stone makes you adept at moving across uneven surfaces. You can ignore difficult terrain caused by rubble and uneven ground made of stone and earth. In addition, when you use the Acrobatics skill to Balance on narrow surfaces or uneven ground made of stone or earth, you aren't flat-footed, and when you roll a success at one of these Acrobatics checks, you get a critical success instead.\r\n"
         },
         {
             "name": "Stonecunning",
@@ -94,27 +101,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=4",
             "prereq": "\u2014",
             "benefits": "You have a knack for noticing even small inconsistencies and craftsmanship techniques in the stonework around you.",
-            "text": [
-                "You have a knack for noticing even small inconsistencies and craftsmanship techniques in the stonework around you. You gain a +2 circumstance bonus to Perception checks to notice unusual stonework. This bonus applies to checks to discover mechanical traps made of stone or hidden within stone.",
-                " If you aren\u2019t using the Seek action or searching, the GM automatically rolls a secret check for you to notice unusual stonework anyway. This check doesn\u2019t gain the circumstance bonus, and it takes a \u20132 circumstance penalty."
-            ]
+            "text": "You have a knack for noticing even small inconsistencies and craftsmanship techniques in the stonework around you. You gain a +2 circumstance bonus to Perception checks to notice unusual stonework. This bonus applies to checks to discover mechanical traps made of stone or hidden within stone. If you aren't using the Seek action or searching, the GM automatically rolls a secret check for you to notice unusual stonework anyway. This check doesn't gain the circumstance bonus, and it takes a \u20132 circumstance penalty.\r\n"
         },
         {
             "name": "Surface Culture",
             "level": "1",
             "traits": [
                 "Dwarf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=967",
             "prereq": "\u2014",
             "benefits": "Your interactions with other cultures on the surface have not only taught you about many other ancestries, but have also helped you realize the value of your own.",
-            "text": [
-                "Your interactions with other cultures on the surface have not only taught you about many other ancestries, but have also helped you realize the value of your own. You gain the trained proficiency rank in the ",
-                " skill (or another skill of your choice if you were already trained in Society), and you gain the ",
-                " skill feat for the ",
-                " corresponding to your culture (for instance, Ouat Lore or Pahmet Lore)."
-            ]
+            "text": "Your interactions with other cultures on the surface have not only taught you about many other ancestries, but have also helped you realize the value of your own. You gain the trained proficiency rank in the Society skill (or another skill of your choice if you were already trained in Society), and you gain the Additional Lore skill feat for the Lore corresponding to your culture (for instance, Ouat Lore or Pahmet Lore)."
         },
         {
             "name": "Unburdened Iron",
@@ -125,10 +124,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=5",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned techniques first devised by your ancestors during their ancient wars, allowing you to comfortably wear massive suits of armor.",
-            "text": [
-                "You\u2019ve learned techniques first devised by your ancestors during their ancient wars, allowing you to comfortably wear massive suits of armor. Ignore the reduction to your Speed from any armor you wear.",
-                " In addition, any time you\u2019re taking a penalty to your Speed from some other reason (such as from the encumbered condition or from a spell), deduct 5 feet from the penalty. For example, the encumbered condition normally gives a \u201310-foot penalty to Speed, but it gives you only a \u20135-foot penalty. If your Speed is taking multiple penalties, pick only one penalty to reduce."
-            ]
+            "text": "You've learned techniques first devised by your ancestors during their ancient wars, allowing you to comfortably wear massive suits of armor. Ignore the reduction to your Speed from any armor you wear. In addition, any time you're taking a penalty to your Speed from some other reason (such as from the encumbered condition or from a spell), deduct 5 feet from the penalty. For example, the encumbered condition normally gives a \u201310-foot penalty to Speed, but it gives you only a \u20135-foot penalty. If your Speed is taking multiple penalties, pick only one penalty to reduce.\r\n"
         },
         {
             "name": "Vengeful Hatred",
@@ -139,10 +135,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=6",
             "prereq": "\u2014",
             "benefits": "You heart aches for vengeance against those who have wronged your people.",
-            "text": [
-                "You heart aches for vengeance against those who have wronged your people. Choose one of the following dwarven ancestral foes when you gain Vengeful Hatred: drow, duergar, giant, or orc. You gain a +1 circumstance bonus to damage with weapons and unarmed attacks against creatures with that trait. If your attack would deal more than one weapon die of damage (as is common at higher levels than 1st), the bonus is equal to the number of weapon dice or unarmed attack dice. In addition, if a creature critically succeeds at an attack against you and deals damage to you, you gain your bonus to damage against that creature for 1 minute regardless of whether it has the chosen trait.",
-                " Your GM can add appropriate creature traits to the ancestral foes list if your character is from a community that commonly fights other types of enemies."
-            ]
+            "text": "You heart aches for vengeance against those who have wronged your people. Choose one of the following dwarven ancestral foes when you gain Vengeful Hatred: drow, duergar, giant, or orc. You gain a +1 circumstance bonus to damage with weapons and unarmed attacks against creatures with that trait. If your attack would deal more than one weapon die of damage (as is common at higher levels than 1st), the bonus is equal to the number of weapon dice or unarmed attack dice. In addition, if a creature critically succeeds at an attack against you and deals damage to you, you gain your bonus to damage against that creature for 1 minute regardless of whether it has the chosen trait.\r\n"
         },
         {
             "name": "Boulder Roll",
@@ -153,10 +146,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=7",
             "prereq": "Rock Runner",
             "benefits": "Your dwarven build allows you to push foes around, just like a mighty boulder.",
-            "text": [
-                "Your dwarven build allows you to push foes around, just like a mighty boulder tumbles through a subterranean cavern. Take a Step into the square of a foe that is your size or smaller, and the foe must move into the empty space directly behind it. The foe must move even if doing so places it in harm\u2019s way. The foe can attempt a Fortitude saving throw against your Athletics DC to block your Step. If the foe attempts this saving throw, unless it critically succeeds, it takes bludgeoning damage equal to your level plus your Strength modifier.",
-                " If the foe can\u2019t move into an empty space (if it is surrounded by solid objects or other creatures, for example), your Boulder Roll has no effect."
-            ]
+            "text": "Your dwarven build allows you to push foes around, just like a mighty boulder tumbles through a subterranean cavern. Take a Step into the square of a foe that is your size or smaller, and the foe must move into the empty space directly behind it. The foe must move even if doing so places it in harm's way. The foe can attempt a Fortitude saving throw against your Athletics DC to block your Step. If the foe attempts this saving throw, unless it critically succeeds, it takes bludgeoning damage equal to your level plus your Strength modifier. If the foe can't move into an empty space (if it is surrounded by solid objects or other creatures, for example), your Boulder Roll has no effect.\r\n"
         },
         {
             "name": "Clan Protector",
@@ -167,10 +157,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=968",
             "prereq": "\u2014",
             "benefits": "Your clan dagger can protect your allies as easily as yourself.",
-            "text": [
-                "Your ",
-                " can protect your allies as easily as yourself. When you use an Interact action to gain a circumstance bonus to AC from your clan dagger\u2019s parry trait, you can grant the circumstance bonus to an adjacent ally instead of gaining it yourself. You can use multiple Interact actions to protect multiple allies, or to protect yourself and an ally. The ally benefits from the bonus to AC only when they are adjacent to you."
-            ]
+            "text": "Your clan dagger can protect your allies as easily as yourself. When you use an Interact action to gain a circumstance bonus to AC from your clan dagger\u2019s parry trait, you can grant the circumstance bonus to an adjacent ally instead of gaining it yourself. You can use multiple Interact actions to protect multiple allies, or to protect yourself and an ally. The ally benefits from the bonus to AC only when they are adjacent to you."
+        },
+        {
+            "name": "Defy the Darkness",
+            "level": "5",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1399",
+            "prereq": "darkvision",
+            "benefits": "Using ancient dwarven methods developed to fight enemies wielding magical darkness, you've honed your darkvision and sworn not to use such magic yourself.",
+            "text": "Using ancient dwarven methods developed to fight enemies wielding magical darkness, you've honed your darkvision and sworn not to use such magic yourself. You gain greater darkvision, enabling you to see through magical darkness even if it normally hampers darkvision (such as the darkness created by a 4th-level darkness spell). You can't cast spells with the darkness trait, use item activations with the darkness trait, or use any other ability with the darkness trait."
+        },
+        {
+            "name": "Dwarven Reinforcement",
+            "level": "5",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1400",
+            "prereq": "expert in Crafting",
+            "benefits": "You can use your knowledge of engineering and metalwork to temporarily strengthen thick objects and structures.",
+            "text": "You can use your knowledge of engineering and metalwork to temporarily strengthen thick objects and structures. By spending 1 hour working on an item, you can give it a +1 circumstance bonus to its Hardness for 24 hours. If you're a master in Crafting, the bonus is +2, and if you're legendary, the bonus is +3. You can reinforce a portion of a structure, though 1 hour usually reinforces only a door, a few windows, or another section that fits within a 10-foot cube."
         },
         {
             "name": "Dwarven Weapon Cunning",
@@ -181,9 +190,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=8",
             "prereq": "Dwarven Weapon Familiarity",
             "benefits": "You\u2019ve learned cunning techniques to get the best effects out of your dwarven weapons.",
-            "text": [
-                "You\u2019ve learned cunning techniques to get the best effects out of your dwarven weapons. Whenever you critically hit using a battle axe, pick, warhammer, or a dwarf weapon, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You've learned cunning techniques to get the best effects out of your dwarven weapons. Whenever you critically hit using a battle axe, pick, warhammer, or a dwarf weapon, you apply the weapon's critical specialization effect.\r\n"
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Dwarf",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Protective Sheath",
@@ -194,25 +213,30 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=969",
             "prereq": "Clan\u2019s Edge",
             "benefits": "When you lash out with your clan dagger, you keep its sheath close at hand.",
-            "text": [
-                "When you lash out with your ",
-                ", you keep its sheath close at hand. When you use Clan\u2019s Edge, if the hand you\u2019re not holding the dagger with is empty, you can use your clan dagger\u2019s sheath to block attacks as well. The circumstance bonus to your AC from parrying increases to a +2 against any target you hit with a Strike this turn."
-            ]
+            "text": "When you lash out with your clan dagger, you keep its sheath close at hand. When you use Clan\u2019s Edge, if the hand you\u2019re not holding the dagger with is empty, you can use your clan dagger\u2019s sheath to block attacks as well. The circumstance bonus to your AC from parrying increases to a +2 against any target you hit with a Strike this turn."
+        },
+        {
+            "name": "Sheltering Slab",
+            "level": "5",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1401",
+            "prereq": "\u2014",
+            "benefits": "The stone around you is your ally, and you have learned to use it to shore up your weaknesses.",
+            "text": "The stone around you is your ally, and you have learned to use it to shore up your weaknesses. As long as you remain on the ground and are adjacent to a vertical stone wall that rises to your height or taller, you aren't flat-footed against attacks as a result of being flanked. This works even if you are at the outside corner of the wall."
         },
         {
             "name": "Tomb-Watcher's Glare",
             "level": "5",
             "traits": [
                 "Dwarf",
-                " Divine"
+                "Divine"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=970",
             "prereq": "death warden dwarf heritage",
             "benefits": "When you critically hit an undead creature, or an undead creature critically fails a saving throw against one of your abilities, you drive your divine wrath home in your enemy\u2019s heart.",
-            "text": [
-                "When you critically hit an undead creature, or an undead creature critically fails a saving throw against one of your abilities, you drive your divine wrath home in your enemy\u2019s heart. The undead is ",
-                " 1 for 1 round."
-            ]
+            "text": "When you critically hit an undead creature, or an undead creature critically fails a saving throw against one of your abilities, you drive your divine wrath home in your enemy\u2019s heart. The undead is enfeebled 1 for 1 round."
         },
         {
             "name": "Battleforger",
@@ -223,11 +247,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=971",
             "prereq": "master in Crafting",
             "benefits": "You can sharpen weapons, polish armor, and apply special techniques to temporarily gain better effects from your armaments.",
-            "text": [
-                "You can sharpen weapons, polish armor, and apply special techniques to temporarily gain better effects from your armaments. By spending 1 hour working on a weapon or armor, you can grant it the effects of a ",
-                " rune until your next daily preparations, gaining a +1 item bonus to attack rolls for a weapon or increasing armor\u2019s item bonus to AC by 1. This has no effect if the weapon or armor already had a ",
-                " rune."
-            ]
+            "text": "You can sharpen weapons, polish armor, and apply special techniques to temporarily gain better effects from your armaments. By spending 1 hour working on a weapon or armor, you can grant it the effects of a +1 potency rune until your next daily preparations, gaining a +1 item bonus to attack rolls for a weapon or increasing armor\u2019s item bonus to AC by 1. This has no effect if the weapon or armor already had a potency rune."
+        },
+        {
+            "name": "Echoes in Stone",
+            "level": "9",
+            "traits": [
+                "Dwarf",
+                "Concentrate"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1402",
+            "prereq": "\u2014",
+            "benefits": "You pause a moment to attune your senses to the stone around you.",
+            "text": "You pause a moment to attune your senses to the stone around you. Until the start of your next turn, you gain a new sense: imprecise tremorsense with a range of 20 feet."
         },
         {
             "name": "Energy Blessed",
@@ -238,10 +270,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=972",
             "prereq": "elemental heart dwarf heritage",
             "benefits": "Energy runs through your blood more powerfully.",
-            "text": [
-                "Energy runs through your blood more powerfully. When you use ",
-                ", you can create an emanation of 5 feet, 10 feet, or 15 feet. The damage increases to 6d6 plus an additional 1d6 for every level you have above 9th, instead of 1d6 plus an additional 1d6 for every 2 levels above 1st."
-            ]
+            "text": "Energy runs through your blood more powerfully. When you use Energy Emanation, you can create an emanation of 5 feet, 10 feet, or 15 feet. The damage increases to 6d6 plus an additional 1d6 for every level you have above 9th, instead of 1d6 plus an additional 1d6 for every 2 levels above 1st."
         },
         {
             "name": "Heroes' Call",
@@ -252,10 +281,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=973",
             "prereq": "\u2014",
             "benefits": "The songs of ancient heroes echo through your mind and quicken your pulse, especially in dire straits.",
-            "text": [
-                "The songs of ancient heroes echo through your mind and quicken your pulse, especially in dire straits. You gain ",
-                " as a 3rd-level innate occult spell that you can cast once per day. If you Cast the Spell when you have half or fewer Hit Points, you also gain temporary Hit Points equal to twice your level."
-            ]
+            "text": "The songs of ancient heroes echo through your mind and quicken your pulse, especially in dire straits. You gain heroism as a 3rd-level innate occult spell that you can cast once per day. If you Cast the Spell when you have half or fewer Hit Points, you also gain temporary Hit Points equal to twice your level."
         },
         {
             "name": "Kneel for No God",
@@ -266,10 +292,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=974",
             "prereq": "ancient-blooded dwarf heritage",
             "benefits": "Your ancestors\u2019 defiance of magic and your people\u2019s strictly egalitarian mindset mean that certain forms of magic have little effect on you.",
-            "text": [
-                "Your ancestors\u2019 defiance of magic and your people\u2019s strictly egalitarian mindset mean that certain forms of magic have little effect on you. When you use your ",
-                " reaction against a divine spell and roll a critical failure on the saving throw against that spell, you get a failure instead."
-            ]
+            "text": "Your ancestors\u2019 defiance of magic and your people\u2019s strictly egalitarian mindset mean that certain forms of magic have little effect on you. When you use your Call on Ancient Blood reaction against a divine spell and roll a critical failure on the saving throw against that spell, you get a failure instead."
         },
         {
             "name": "Mountain's Stoutness",
@@ -280,12 +303,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=9",
             "prereq": "\u2014",
             "benefits": "Your hardiness lets you withstand more punishment than most before going down.",
-            "text": [
-                "Your hardiness lets you withstand more punishment than most before going down. Increase your maximum Hit Points by your level. When you have the ",
-                " condition, the DC of your recovery checks is equal to 9 + your dying value (instead of 10 + your dying value).",
-                "If you also have the ",
-                " feat, the Hit Points gained from it and this feat are cumulative, and the DC of your recovery checks is equal to 6 + your dying value."
-            ]
+            "text": "Your hardiness lets you withstand more punishment than most before going down. Increase your maximum Hit Points by your level. When you have the dying condition, the DC of your recovery checks is equal to 9 + your dying value (instead of 10 + your dying value).If you also have the Toughness feat, the Hit Points gained from it and this feat are cumulative, and the DC of your recovery checks is equal to 6 + your dying value."
+        },
+        {
+            "name": "Returning Throw",
+            "level": "9",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1403",
+            "prereq": "\u2014",
+            "benefits": "You have mastered the technique of arcing a projectile so that it returns to your hand after being thrown, though this requires a moment to precisely calculate the trajectory and possible ricochets.",
+            "text": "You have mastered the technique of arcing a projectile so that it returns to your hand after being thrown, though this requires a moment to precisely calculate the trajectory and possible ricochets. Make a ranged Strike with a thrown weapon. Once the Strike is complete, the weapon arcs or ricochets back to your hand. If your hands are full when the weapon returns, it falls to the ground in your space."
+        },
+        {
+            "name": "Stone Bones",
+            "level": "9",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1404",
+            "prereq": "\u2014",
+            "benefits": "Your intractable nature can help you shrug off even the most grievous injuries.",
+            "text": "Your intractable nature can help you shrug off even the most grievous injuries. Attempt a DC 17 flat check. If you are successful, the attack becomes a normal hit."
         },
         {
             "name": "Stonewalker",
@@ -296,12 +336,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=10",
             "prereq": "\u2014",
             "benefits": "You have a deep reverence for and connection to stone.",
-            "text": [
-                "You have a deep reverence for and connection to stone. You gain ",
-                " as a 3rd-level divine innate spell that you can cast once per day.",
-                " If you have the ",
-                " dwarf ancestry feat, you can attempt to find unusual stonework and stonework traps that require legendary proficiency in Perception. If you have both Stonecunning and legendary proficiency in Perception, when you\u2019re not Seeking and the GM rolls a secret check for you to notice unusual stonework, you keep the bonus from Stonecunning and don\u2019t take the \u20132 circumstance penalty."
-            ]
+            "text": "You have a deep reverence for and connection to stone. You gain meld into stone as a 3rd-level divine innate spell that you can cast once per day. If you have the Stonecunning dwarf ancestry feat, you can attempt to find unusual stonework and stonework traps that require legendary proficiency in Perception. If you have both Stonecunning and legendary proficiency in Perception, when you're not Seeking and the GM rolls a secret check for you to notice unusual stonework, you keep the bonus from Stonecunning and don't take the \u20132 circumstance penalty.\r\n"
         },
         {
             "name": "Dwarven Weapon Expertise",
@@ -312,12 +347,43 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=11",
             "prereq": "Dwarven Weapon Familiarity",
             "benefits": "Your dwarven affinity blends with your training, granting you great skill with dwarven weapons.",
-            "text": [
-                "Your dwarven affinity blends with your training, granting you great skill with dwarven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency for battle axes, picks, warhammers, and all dwarven weapons in which you are trained."
-            ]
+            "text": "Your dwarven affinity blends with your training, granting you great skill with dwarven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency for battle axes, picks, warhammers, and all dwarven weapons in which you are trained."
+        },
+        {
+            "name": "Telluric Power",
+            "level": "13",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1405",
+            "prereq": "\u2014",
+            "benefits": "You channel strength from the earth beneath your feet to pummel your enemies.",
+            "text": "You channel strength from the earth beneath your feet to pummel your enemies. When making a melee Strike against a target who is standing on the same earth or stone surface as you are, you gain a circumstance bonus to the damage roll equal to the number of weapon damage dice."
+        },
+        {
+            "name": "Stonegate",
+            "level": "17",
+            "traits": [
+                "Dwarf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1406",
+            "prereq": "Stonewalker",
+            "benefits": "Earthen barriers no longer impede your progress.",
+            "text": "Earthen barriers no longer impede your progress. You gain passwall as a 7th-level divine innate spell that you can cast once per day. Unlike the spell, however, this ability can be used only to open passages through barriers of earth or stone."
         }
     ],
     " elfFeats": [
+        {
+            "name": "Ancestral Linguistics",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1407",
+            "prereq": "at least 100 years old",
+            "benefits": "Over your extensive lifespan, you've studied many languages.",
+            "text": "Over your extensive lifespan, you've studied many languages. During your daily preparations, you can recede into old memories to become fluent in one common language or one other language you have access to. You know this language until you prepare again. Since this knowledge is temporary, you can't use it as a prerequisite for a permanent character option."
+        },
         {
             "name": "Ancestral Longevity",
             "level": "1",
@@ -327,9 +393,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=12",
             "prereq": "at least 100 years old",
             "benefits": "You have accumulated a vast array of lived knowledge over the years.",
-            "text": [
-                "You have accumulated a vast array of lived knowledge over the years. During your daily preparations, you can reflect upon your life experiences to gain the trained proficiency rank in one skill of your choice. This proficiency lasts until you prepare again. Since this proficiency is temporary, you can\u2019t use it as a prerequisite for a skill increase or a permanent character option like a feat."
-            ]
+            "text": "You have accumulated a vast array of lived knowledge over the years. During your daily preparations, you can reflect upon your life experiences to gain the trained proficiency rank in one skill of your choice. This proficiency lasts until you prepare again. Since this proficiency is temporary, you can\u2019t use it as a prerequisite for a skill increase or a permanent character option like a feat."
         },
         {
             "name": "Elemental Wrath",
@@ -340,11 +404,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=975",
             "prereq": "\u2014",
             "benefits": "You are so attuned to the land that you can call forth a bolt of energy from your surroundings.",
-            "text": [
-                "You are so attuned to the land that you can call forth a bolt of energy from your surroundings. When you gain this feat, select acid, cold, electricity, or fire. You can call to the land to cast the ",
-                " cantrip as an innate primal spell at will, except the spell has only verbal components and deals the type of damage you chose instead of acid damage; the spell gains the trait appropriate to its damage instead of the ",
-                " trait. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "You are so attuned to the land that you can call forth a bolt of energy from your surroundings. When you gain this feat, select acid, cold, electricity, or fire. You can call to the land to cast the acid splash cantrip as an innate primal spell at will, except the spell has only verbal components and deals the type of damage you chose instead of acid damage; the spell gains the trait appropriate to its damage instead of the acid trait. A cantrip is heightened to a spell level equal to half your level rounded up."
+        },
+        {
+            "name": "Elven Aloofness",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1408",
+            "prereq": "\u2014",
+            "benefits": "As much as you might care for them, you've come to terms with the ephemeral nature of non-elves, and it makes their threats feel less troublesome.",
+            "text": "As much as you might care for them, you've come to terms with the ephemeral nature of non-elves, and it makes their threats feel less troublesome. If a non-elf rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (and thus can't try to Coerce you again for 1 week). When a non-elf attempts to Demoralize you, you become temporarily immune for 1 day, instead of 10 minutes."
         },
         {
             "name": "Elven Lore",
@@ -355,9 +426,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=13",
             "prereq": "\u2014",
             "benefits": "You\u2019ve studied in traditional elven arts, learning about arcane magic and the world around you.",
-            "text": [
-                "You\u2019ve studied in traditional elven arts, learning about arcane magic and the world around you. You gain the trained proficiency rank in Arcana and Nature. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Elven Lore."
-            ]
+            "text": "You've studied in traditional elven arts, learning about arcane magic and the world around you. You gain the trained proficiency rank in Arcana and Nature. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Elven Lore.\r\n"
         },
         {
             "name": "Elven Verve",
@@ -368,13 +437,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=976",
             "prereq": "\u2014",
             "benefits": "While all elves are immune to the paralyzing touch of ghouls, you can shake off flesh-numbing magic of all kinds.",
-            "text": [
-                "While all elves are immune to the paralyzing touch of ",
-                ", you can shake off flesh-numbing magic of all kinds. You gain a +1 circumstance bonus to saves against effects that would impose the ",
-                ", ",
-                ", or ",
-                " conditions. When you would be immobilized, paralyzed, or slowed for at least 2 rounds, reduce that duration by 1 round."
-            ]
+            "text": "While all elves are immune to the paralyzing touch of ghouls, you can shake off flesh-numbing magic of all kinds. You gain a +1 circumstance bonus to saves against effects that would impose the immobilized, paralyzed, or slowed conditions. When you would be immobilized, paralyzed, or slowed for at least 2 rounds, reduce that duration by 1 round."
         },
         {
             "name": "Elven Weapon Familiarity",
@@ -385,10 +448,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=14",
             "prereq": "\u2014",
             "benefits": "You favor bows and other elegant weapons.",
-            "text": [
-                "You favor bows and other elegant weapons. You are trained with longbows, composite longbows, longswords, rapiers, shortbows, and composite shortbows.",
-                " In addition, you gain access to all uncommon elf weapons. For the purpose of determining your proficiency, martial elf weapons are simple weapons and advanced elf weapons are martial weapons."
-            ]
+            "text": "You favor bows and other elegant weapons. You are trained with longbows, composite longbows, longswords, rapiers, shortbows, and composite shortbows. In addition, you gain access to all uncommon elf weapons. For the purpose of determining your proficiency, martial elf weapons are simple weapons and advanced elf weapons are martial weapons.\r\n"
         },
         {
             "name": "Forlorn",
@@ -399,9 +459,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=15",
             "prereq": "\u2014",
             "benefits": "Watching your friends age and die fills you with moroseness that protects you against harmful emotions.",
-            "text": [
-                "Watching your friends age and die fills you with moroseness that protects you against harmful emotions. You gain a +1 circumstance bonus to saving throws against emotion effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead."
-            ]
+            "text": "Watching your friends age and die fills you with moroseness that protects you against harmful emotions. You gain a +1 circumstance bonus to saving throws against emotion effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead.\r\n"
+        },
+        {
+            "name": "Know Your Own",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1409",
+            "prereq": "\u2014",
+            "benefits": "You've spent countless hours studying the history of elves on your world and beyond and are a studied expert in your people's ways.",
+            "text": "You've spent countless hours studying the history of elves on your world and beyond and are a studied expert in your people's ways. If you critically fail a check to Recall Knowledge about elves, elven society, or elven history, you get a failure instead."
         },
         {
             "name": "Nimble Elf",
@@ -412,9 +481,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=16",
             "prereq": "\u2014",
             "benefits": "Your muscles are tightly honed.",
-            "text": [
-                "Your muscles are tightly honed. Your Speed increases by 5 feet."
-            ]
+            "text": "Your muscles are tightly honed. Your Speed increases by 5 feet."
         },
         {
             "name": "Otherworldly Magic",
@@ -425,10 +492,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=17",
             "prereq": "\u2014",
             "benefits": "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic.",
-            "text": [
-                "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic. Choose one cantrip from the ",
-                " spell list. You can cast this cantrip as an arcane innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic. Choose one cantrip from the arcane spell list. You can cast this cantrip as an arcane innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
         },
         {
             "name": "Share Thoughts",
@@ -439,10 +503,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=977",
             "prereq": "Mualijae, Ilverani, or Vourinoi ethnicity",
             "benefits": "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers.",
-            "text": [
-                "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers. You can cast ",
-                " as an innate occult spell once per day, but you can target only other elves or half-elves."
-            ]
+            "text": "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers. You can cast mindlink as an innate occult spell once per day, but you can target only other elves or half-elves."
         },
         {
             "name": "Unwavering Mien",
@@ -453,25 +514,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=18",
             "prereq": "\u2014",
             "benefits": "Your mystic control and meditations allow you to resist external influences upon your consciousness.",
-            "text": [
-                "Your mystic control and meditations allow you to resist external influences upon your consciousness. Whenever you are affected by a mental effect that lasts at least 2 rounds, you can reduce the duration by 1 round.",
-                " You still require natural sleep, but you treat your saving throws against effects that would cause you to fall asleep as one degree of success better. This protects only against sleep effects, not against other forms of falling unconscious."
-            ]
+            "text": "Your mystic control and meditations allow you to resist external influences upon your consciousness. Whenever you are affected by a mental effect that lasts at least 2 rounds, you can reduce the duration by 1 round. You still require natural sleep, but you treat your saving throws against effects that would cause you to fall asleep as one degree of success better. This protects only against sleep effects, not against other forms of falling unconscious.\r\n"
         },
         {
             "name": "Wildborn Magic",
             "level": "1",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=978",
             "prereq": "\u2014",
             "benefits": "You have learned to access the old magic of wild places.",
-            "text": [
-                "You have learned to access the old magic of wild places. Choose one cantrip from the ",
-                " spell list. You can cast this cantrip as an innate primal spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "You have learned to access the old magic of wild places. Choose one cantrip from the primal spell list. You can cast this cantrip as an innate primal spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
         },
         {
             "name": "Woodcraft",
@@ -482,10 +537,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=979",
             "prereq": "\u2014",
             "benefits": "You have a innate familiarity with forested areas.",
-            "text": [
-                "You have a innate familiarity with forested areas. When in a forest or jungle environment, if you roll a critical failure on a ",
-                " skill check to Sense Direction, Subsist, or Cover Tracks, you get a failure instead, and if you roll a success, you get a critical success instead."
-            ]
+            "text": "You have a innate familiarity with forested areas. When in a forest or jungle environment, if you roll a critical failure on a Survival skill check to Sense Direction, Subsist, or Cover Tracks, you get a failure instead, and if you roll a success, you get a critical success instead."
         },
         {
             "name": "Ageless Patience",
@@ -496,29 +548,30 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=19",
             "prereq": "\u2014",
             "benefits": "You work at a pace born from longevity that enhances your thoroughness.",
-            "text": [
-                "You work at a pace born from longevity that enhances your thoroughness. You can voluntarily spend twice as much time as normal on a Perception check or skill check to gain a +2 circumstance bonus to that check. You also don\u2019t treat a natural 1 as worse than usual on these checks; you get a critical failure only if your result is 10 lower than the DC. For example, you could get these benefits if you spent 2 actions to Seek, which normally takes 1 action. You can get these benefits during exploration by taking twice as long exploring as normal, or in downtime by spending twice as much downtime.",
-                " The GM might determine a situation doesn\u2019t grant you a benefit if a delay would be directly counterproductive to your success, such as a tense negotiation with an impatient creature."
-            ]
+            "text": "You work at a pace born from longevity that enhances your thoroughness. You can voluntarily spend twice as much time as normal on a Perception check or skill check to gain a +2 circumstance bonus to that check. You also don't treat a natural 1 as worse than usual on these checks; you get a critical failure only if your result is 10 lower than the DC. For example, you could get these benefits if you spent 2 actions to Seek, which normally takes 1 action. You can get these benefits during exploration by taking twice as long exploring as normal, or in downtime by spending twice as much downtime. The GM might determine a situation doesn't grant you a benefit if a delay would be directly counterproductive to your success, such as a tense negotiation with an impatient creature.\r\n"
+        },
+        {
+            "name": "Ancestral Suspicion",
+            "level": "5",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1410",
+            "prereq": "\u2014",
+            "benefits": "Long-lived elves have seen civilizations rise and fall, often at the hands of outside forces.",
+            "text": "Long-lived elves have seen civilizations rise and fall, often at the hands of outside forces. As a result, they have developed a wariness of others who might seek to influence or control them. You've been trained to resist such manipulation, gaining a +2 circumstance bonus to saving throws against effects that would make you controlled, such as dominate, and to Perception checks to Sense Motive when trying to determine if a creature is under the influence of such an effect. When you roll a success on a saving throw against such an effect, you get a critical success instead."
         },
         {
             "name": "Defiance Unto Death",
             "level": "5",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=980",
             "prereq": "\u2014",
             "benefits": "You loathe the alghollthus and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation.",
-            "text": [
-                "You loathe the ",
-                " and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation. If you would start your turn ",
-                ", ",
-                ", or ",
-                " due to a failed Will save, you can attempt a Will save against the same DC; on a success, you become ",
-                " until your next turn, rather than act against your will."
-            ]
+            "text": "You loathe the alghollthus and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation. If you would start your turn confused, controlled, or fleeing due to a failed Will save, you can attempt a Will save against the same DC; on a success, you become paralyzed until your next turn, rather than act against your will."
         },
         {
             "name": "Elven Instincts",
@@ -529,9 +582,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=981",
             "prereq": "\u2014",
             "benefits": "Your senses let you react rapidly.",
-            "text": [
-                "Your senses let you react rapidly. You gain a +2 circumstance bonus to Perception checks made as initiative rolls. Additionally, if your initiative roll result is tied with that of an opponent, you go first, regardless of whether you rolled Perception or not."
-            ]
+            "text": "Your senses let you react rapidly. You gain a +2 circumstance bonus to Perception checks made as initiative rolls. Additionally, if your initiative roll result is tied with that of an opponent, you go first, regardless of whether you rolled Perception or not."
         },
         {
             "name": "Elven Weapon Elegance",
@@ -542,10 +593,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=20",
             "prereq": "Elven Weapon Familiarity",
             "benefits": "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them.",
-            "text": [
-                "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them. Whenever you critically hit using an elf weapon or one of the weapons listed in ",
-                ", you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them. Whenever you critically hit using an elf weapon or one of the weapons listed in Elven Weapon Familiarity, you apply the weapon's critical specialization effect.\r\n"
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Elf",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Forest Stealth",
@@ -556,10 +616,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=982",
             "prereq": "Expert in Stealth",
             "benefits": "You are skilled at quickly hiding behind bits of underbrush or foliage.",
-            "text": [
-                "You are skilled at quickly hiding behind bits of underbrush or foliage. You ",
-                " and then use that cover to Hide."
-            ]
+            "text": "You are skilled at quickly hiding behind bits of underbrush or foliage. You Take Cover and then use that cover to Hide."
+        },
+        {
+            "name": "Martial Experience",
+            "level": "5",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1411",
+            "prereq": "\u2014",
+            "benefits": "You've crossed blades with a wide variety of foes wielding a wide variety of weapons, and you've learned the basics of fighting with nearly any of them.",
+            "text": "You've crossed blades with a wide variety of foes wielding a wide variety of weapons, and you've learned the basics of fighting with nearly any of them. When wielding a weapon you aren't proficient with, treat your level as your proficiency bonus. At 11th level, you become trained in all weapons."
         },
         {
             "name": "Wildborn Adept",
@@ -570,12 +638,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=983",
             "prereq": "Wildborn Magic",
             "benefits": "The whispers of the jungle grant you more diverse access to simple primal magic.",
-            "text": [
-                "The whispers of the jungle grant you more diverse access to simple primal magic. You can cast ",
-                ", ",
-                ", and ",
-                " as innate primal spells at will. If you chose one of those spells with Wildborn Magic, you can select a new spell for Wildborn Magic."
-            ]
+            "text": "The whispers of the jungle grant you more diverse access to simple primal magic. You can cast dancing lights, disrupt undead, and tanglefoot as innate primal spells at will. If you chose one of those spells with Wildborn Magic, you can select a new spell for Wildborn Magic."
         },
         {
             "name": "Brightness Seeker",
@@ -586,16 +649,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=984",
             "prereq": "\u2014",
             "benefits": "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast augury as an innate divine spell.",
-            "text": [
-                "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast ",
-                " as an innate divine spell. Unless the result of the ",
-                " was \u201cnothing,\u201d you gain the following reaction for the next 30 minutes:",
-                " ",
-                " You attempt an attack roll, skill check, or saving throw while performing the course of action from your ",
-                ", but you haven\u2019t rolled yet",
-                "You gain a +1 status bonus to the triggering check, or a +2 status bonus if the result of the ",
-                " was \u201cwoe\u201d and you proceeded anyway."
-            ]
+            "text": "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast augury as an innate divine spell. Unless the result of the augury was \u201cnothing,\u201d you gain the following reaction for the next 30 minutes:"
         },
         {
             "name": "Elf Step",
@@ -606,9 +660,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=21",
             "prereq": "\u2014",
             "benefits": "You move in a graceful dance, and even your steps are broad.",
-            "text": [
-                "You move in a graceful dance, and even your steps are broad. You Step 5 feet twice."
-            ]
+            "text": "You move in a graceful dance, and even your steps are broad. You Step 5 feet twice."
         },
         {
             "name": "Expert Longevity",
@@ -619,26 +671,53 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=22",
             "prereq": "Ancestral Longevity",
             "benefits": "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life.",
-            "text": [
-                "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life. When you choose a skill in which to become trained with ",
-                ", you can also choose a skill in which you are already trained and become an expert in that skill. This lasts until your Ancestral Longevity expires.",
-                " When the effects of Ancestral Longevity and Expert Longevity expire, you can retrain one of your skill increases. The skill increase you gain from this retraining must either make you trained in the skill you chose with Ancestral Longevity or make you an expert in the skill you chose with Expert Longevity."
-            ]
+            "text": "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life. When you choose a skill in which to become trained with Ancestral Longevity, you can also choose a skill in which you are already trained and become an expert in that skill. This lasts until your Ancestral Longevity expires. When the effects of Ancestral Longevity and Expert Longevity expire, you can retrain one of your skill increases. The skill increase you gain from this retraining must either make you trained in the skill you chose with Ancestral Longevity or make you an expert in the skill you chose with Expert Longevity."
+        },
+        {
+            "name": "Otherworldly Acumen",
+            "level": "9",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1412",
+            "prereq": "at least one innate spell gained from an elf ancestry feat",
+            "benefits": "The arcane magic you possess grows in power and complexity.",
+            "text": "The arcane magic you possess grows in power and complexity. Choose one common 2nd-level spell from the same tradition as an innate spell you previously gained from another elf ancestry feat (from the arcane list if you have Otherworldly Magic, for example). You can cast that spell as an innate spell once per day, using the same tradition as the list you chose the spell from. Your magic is adaptable. By spending 1 day of downtime, you can change the spell you chose to a different common 2nd-level spell from the same tradition."
         },
         {
             "name": "Sense Thoughts",
             "level": "9",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=985",
             "prereq": "Share Thoughts",
             "benefits": "You have an even stranger knack for knowing what other people are thinking.",
-            "text": [
-                "You have an even stranger knack for knowing what other people are thinking. You can cast ",
-                " as an innate occult spell once per day."
-            ]
+            "text": "You have an even stranger knack for knowing what other people are thinking. You can cast mind reading as an innate occult spell once per day."
+        },
+        {
+            "name": "Tree Climber (Elf)",
+            "level": "9",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1413",
+            "prereq": "\u2014",
+            "benefits": "You've spent much of your life among the treetops and have become an expert at quickly and safely climbing them.",
+            "text": "You've spent much of your life among the treetops and have become an expert at quickly and safely climbing them. You gain a climb Speed of 10 feet."
+        },
+        {
+            "name": "Avenge Ally",
+            "level": "13",
+            "traits": [
+                "Elf",
+                "Fortune"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1414",
+            "prereq": "\u2014",
+            "benefits": "Though you know that you will eventually outlive your companions, seeing them at death's door brings clarity to your attacks.",
+            "text": "Though you know that you will eventually outlive your companions, seeing them at death's door brings clarity to your attacks. Make a Strike. Roll twice on the attack roll and use the higher result."
         },
         {
             "name": "Elven Weapon Expertise",
@@ -649,9 +728,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=24",
             "prereq": "Elven Weapon Familiarity",
             "benefits": "Your elven affinity blends with your class training, granting you great skill with elven weapons.",
-            "text": [
-                "Your elven affinity blends with your class training, granting you great skill with elven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all elf weapons in which you are trained."
-            ]
+            "text": "Your elven affinity blends with your class training, granting you great skill with elven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all elf weapons in which you are trained."
         },
         {
             "name": "Universal Longevity",
@@ -662,11 +739,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=23",
             "prereq": "Expert Longevity",
             "benefits": "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life.",
-            "text": [
-                "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life, so you\u2019re almost never truly untrained at a skill. You reflect on your life experiences, changing the skills you selected with ",
-                " and ",
-                "."
-            ]
+            "text": "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life, so you\u2019re almost never truly untrained at a skill. You reflect on your life experiences, changing the skills you selected with Ancestral Longevity and Expert Longevity."
         },
         {
             "name": "Wandering Heart",
@@ -677,12 +750,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=986",
             "prereq": "arctic elf, cavern elf, desert elf, woodland elf, or any other elf heritage based on adapting to an environment",
             "benefits": "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves.",
-            "text": [
-                "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves. After spending a week in an environment associated with an elf heritage (such as snow for arctic elf, or a forest or jungle for woodland elf) your heritage automatically changes to become that heritage. This never causes you to change to an elf heritage that isn\u2019t related to an environment, such as ",
-                ", ",
-                ", or ",
-                "."
-            ]
+            "text": "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves. After spending a week in an environment associated with an elf heritage (such as snow for arctic elf, or a forest or jungle for woodland elf) your heritage automatically changes to become that heritage. This never causes you to change to an elf heritage that isn\u2019t related to an environment, such as ancient elf, seer elf, or whisper elf."
+        },
+        {
+            "name": "Magic Rider",
+            "level": "17",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1415",
+            "prereq": "\u2014",
+            "benefits": "Your people used powerful magic to travel between distant worlds, and the remnants of that magic make such transportation easier for you.",
+            "text": "Your people used powerful magic to travel between distant worlds, and the remnants of that magic make such transportation easier for you. When you are the target of a teleportation spell that transports more than one person, it can affect an additional person beyond the normal limit, chosen by the caster. Additionally, when you're the target of a teleport spell, you and the other targets arrive no farther than 1 mile off target, regardless of distance traveled."
         }
     ],
     " gnomeFeats": [
@@ -695,10 +774,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=25",
             "prereq": "\u2014",
             "benefits": "You build a rapport with an animal, which becomes magically bonded to you.",
-            "text": [
-                "You build a rapport with an animal, which becomes magically bonded to you. You gain a ",
-                " using the rules on page 217. The type of animal is up to you, but most gnomes choose animals with a burrow Speed."
-            ]
+            "text": "You build a rapport with an animal, which becomes magically bonded to you. You gain a familiar. The type of animal is up to you, but most gnomes choose animals with a burrow Speed.\r\n"
         },
         {
             "name": "Burrow Elocutionist",
@@ -709,9 +785,22 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=26",
             "prereq": "\u2014",
             "benefits": "You recognize the chittering of ground creatures as its own peculiar language.",
-            "text": [
-                "You recognize the chittering of ground creatures as its own peculiar language. You can ask questions of, receive answers from, and use the Diplomacy skill with animals that have a burrow Speed, such as badgers, ground squirrels, moles, and prairie dogs. The GM determines which animals count for this ability."
-            ]
+            "text": "You recognize the chittering of ground creatures as its own peculiar language. You can ask questions of, receive answers from, and use the Diplomacy skill with animals that have a burrow Speed, such as badgers, ground squirrels, moles, and prairie dogs. The GM determines which animals count for this ability.\r\n"
+        },
+        {
+            "name": "Empathetic Plea",
+            "level": "1",
+            "traits": [
+                "Gnome",
+                "Auditory",
+                "Emotion",
+                "Mental",
+                "Visual"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1416",
+            "prereq": "trained in Diplomacy",
+            "benefits": "The way you cringe or use those puppydog eyes you've been practicing elicits an empathetic response in the attacker.",
+            "text": "The way you cringe or use those puppydog eyes you've been practicing elicits an empathetic response in the attacker. Attempt a Diplomacy check against your attacker's Will DC."
         },
         {
             "name": "Fey Fellowship",
@@ -722,12 +811,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=27",
             "prereq": "\u2014",
             "benefits": "Your enhanced fey connection affords you a warmer reception from creatures of the First World.",
-            "text": [
-                "Your enhanced fey connection affords you a warmer reception from creatures of the First World as well as tools to foil their tricks. You gain a +2 circumstance bonus to both Perception checks and saving throws against fey.",
-                " In addition, whenever you meet a fey creature in a social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.",
-                " If you have the ",
-                " skill feat, you don\u2019t take the penalty on your immediate Diplomacy check if the target is a fey."
-            ]
+            "text": "Your enhanced fey connection affords you a warmer reception from creatures of the First World as well as tools to foil their tricks. You gain a +2 circumstance bonus to both Perception checks and saving throws against fey. In addition, whenever you meet a fey creature in a social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.\r\n"
         },
         {
             "name": "First World Magic",
@@ -738,10 +822,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=28",
             "prereq": "\u2014",
             "benefits": "Your connection to the First World grants you a primal innate spell, much like those of the fey.",
-            "text": [
-                "Your connection to the First World grants you a primal innate spell, much like those of the fey. Choose one cantrip from the ",
-                " spell list. You can cast this spell as a primal innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "Your connection to the First World grants you a primal innate spell, much like those of the fey. Choose one cantrip from the primal spell list. You can cast this spell as a primal innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up.\r\n"
         },
         {
             "name": "Gnome Obsession",
@@ -752,9 +833,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=29",
             "prereq": "\u2014",
             "benefits": "You might have a flighty nature, but when a topic captures your attention, you dive into it headfirst.",
-            "text": [
-                "You might have a flighty nature, but when a topic captures your attention, you dive into it headfirst. Pick a Lore skill. You gain the trained proficiency rank in that skill. At 2nd level, you gain expert proficiency in the chosen Lore as well as the Lore granted by your background, if any. At 7th level you gain master proficiency in these Lore skills, and at 15th level you gain legendary proficiency in them."
-            ]
+            "text": "You might have a flighty nature, but when a topic captures your attention, you dive into it headfirst. Pick a Lore skill. You gain the trained proficiency rank in that skill. At 2nd level, you gain expert proficiency in the chosen Lore as well as the Lore granted by your background, if any. At 7th level you gain master proficiency in these Lore skills, and at 15th level you gain legendary proficiency in them.\r\n"
         },
         {
             "name": "Gnome Polyglot",
@@ -765,10 +844,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=987",
             "prereq": "\u2014",
             "benefits": "Your extensive travels, curiosity, and love of learning help you to learn languages quickly.",
-            "text": [
-                "Your extensive travels, curiosity, and love of learning help you to learn languages quickly. You learn three new languages, chosen from common languages and uncommon languages you have access to. These languages take the same form (signed or spoken) as your other languages. When you select the ",
-                " feat, you learn three new languages instead of two."
-            ]
+            "text": "Your extensive travels, curiosity, and love of learning help you to learn languages quickly. You learn three new languages, chosen from common languages and uncommon languages you have access to. These languages take the same form (signed or spoken) as your other languages. When you select the Multilingual feat, you learn three new languages instead of two."
         },
         {
             "name": "Gnome Weapon Familiarity",
@@ -779,10 +855,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=30",
             "prereq": "\u2014",
             "benefits": "You favor unusual weapons tied to your people, such as blades with curved and peculiar shapes.",
-            "text": [
-                "You favor unusual weapons tied to your people, such as blades with curved and peculiar shapes. You are trained with the glaive and kukri.",
-                " In addition, you gain access to kukris and all uncommon gnome weapons. For the purpose of determining your proficiency, martial gnome weapons are simple weapons and advanced gnome weapons are martial weapons."
-            ]
+            "text": "You favor unusual weapons tied to your people, such as blades with curved and peculiar shapes. You are trained with the glaive and kukri. In addition, you gain access to kukris and all uncommon gnome weapons. For the purpose of determining your proficiency, martial gnome weapons are simple weapons and advanced gnome weapons are martial weapons.\r\n"
         },
         {
             "name": "Grim Insight",
@@ -793,11 +866,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=988",
             "prereq": "umbral gnome heritage",
             "benefits": "Others\u2019 attempts to scare you often grant you insights about your would-be bullies that you can then exploit.",
-            "text": [
-                "Others\u2019 attempts to scare you often grant you insights about your would-be bullies that you can then exploit. If you roll a success on a saving throw against a ",
-                " effect, you get a critical success instead, and the source of the fear effect is ",
-                " to you until the end of your next turn."
-            ]
+            "text": "Others\u2019 attempts to scare you often grant you insights about your would-be bullies that you can then exploit. If you roll a success on a saving throw against a fear effect, you get a critical success instead, and the source of the fear effect is flat-footed to you until the end of your next turn."
         },
         {
             "name": "Illusion Sense",
@@ -808,9 +877,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=31",
             "prereq": "\u2014",
             "benefits": "Your ancestors spent their days cloaked and cradled in illusions, and as a result, sensing illusion magic is second nature to you.",
-            "text": [
-                "Your ancestors spent their days cloaked and cradled in illusions, and as a result, sensing illusion magic is second nature to you. You gain a +1 circumstance bonus to both Perception checks and Will saves against illusions. When you come within 10 feet of an illusion that can be disbelieved, the GM rolls a secret check for you to disbelieve it, even if you didn\u2019t spend an action to Interact with the illusion."
-            ]
+            "text": "Your ancestors spent their days cloaked and cradled in illusions, and as a result, sensing illusion magic is second nature to you. You gain a +1 circumstance bonus to both Perception checks and Will saves against illusions. When you come within 10 feet of an illusion that can be disbelieved, the GM rolls a secret check for you to disbelieve it, even if you didn't spend an action to Interact with the illusion.\r\n"
         },
         {
             "name": "Inventive Offensive",
@@ -821,16 +888,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=989",
             "prereq": "trained in Crafting",
             "benefits": "You can jury-rig your weapons to perform in unexpected ways.",
-            "text": [
-                "You can jury-rig your weapons to perform in unexpected ways. When you use this ability, add one of the following weapon traits to a melee weapon you wield: ",
-                ", ",
-                ", ",
-                ", ",
-                ", ",
-                ", ",
-                " B, versatile P, or versatile S. You cannot add a trait that the weapon already has. The weapon retains this trait until you a successfully hit and deal damage with the weapon. The weapon retains this trait only while you wield it, and you can have only one weapon modified in this way at any time.",
-                " If you have expert proficiency in Crafting, you can use this feat as a 2-action activity. If you have legendary proficiency in Crafting, you can apply two weapon traits from the list when using this feat."
-            ]
+            "text": "You can jury-rig your weapons to perform in unexpected ways. When you use this ability, add one of the following weapon traits to a melee weapon you wield: deadly d6, disarm, nonlethal, shove, trip, versatile B, versatile P, or versatile S. You cannot add a trait that the weapon already has. The weapon retains this trait until you a successfully hit and deal damage with the weapon. The weapon retains this trait only while you wield it, and you can have only one weapon modified in this way at any time. If you have expert proficiency in Crafting, you can use this feat as a 2-action activity. If you have legendary proficiency in Crafting, you can apply two weapon traits from the list when using this feat."
         },
         {
             "name": "Life-Giving Magic",
@@ -841,9 +899,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=990",
             "prereq": "\u2014",
             "benefits": "The upwelling of innate magic refreshes your body.",
-            "text": [
-                "The upwelling of innate magic refreshes your body. You gain a number of temporary Hit Points equal to half your level (minimum 1) that last until the end of your next turn."
-            ]
+            "text": "The upwelling of innate magic refreshes your body. You gain a number of temporary Hit Points equal to half your level (minimum 1) that last until the end of your next turn."
         },
         {
             "name": "Natural Performer",
@@ -854,10 +910,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=991",
             "prereq": "\u2014",
             "benefits": "Entertainment comes naturally to you.",
-            "text": [
-                "Entertainment comes naturally to you. You become trained in ",
-                " and gain one 1st-level Performance skill feat."
-            ]
+            "text": "Entertainment comes naturally to you. You become trained in Performance and gain one 1st-level Performance skill feat."
+        },
+        {
+            "name": "Razzle-Dazzle",
+            "level": "1",
+            "traits": [
+                "Gnome"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1417",
+            "prereq": "\u2014",
+            "benefits": "You've spent considerable time practicing the manipulation of light, weaponizing your blade's reflection or bolstering the luminosity of magical displays to unconventional heights.",
+            "text": "You've spent considerable time practicing the manipulation of light, weaponizing your blade's reflection or bolstering the luminosity of magical displays to unconventional heights. Extend the duration of the blinded or dazzled condition you give the target by 1 round."
         },
         {
             "name": "Theoretical Acumen",
@@ -868,11 +932,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=992",
             "prereq": "\u2014",
             "benefits": "You study a creature\u2019s form and behavior to hypothesize likely means of overcoming its strengths.",
-            "text": [
-                "You study a creature\u2019s form and behavior to hypothesize likely means of overcoming its strengths. Once before the end of your next turn, you can use the skill modifier from the triggering check in place of your saving throw modifier against one of the creature\u2019s abilities, in place of your Perception modifier to Seek the creature, in place of your ",
-                " modifier to Feint against the creature, or in place of your ",
-                " modifier to Demoralize the creature. Alternatively, against one of the creature\u2019s attacks, you can use your DC for the skill used in the triggering check in place of your AC."
-            ]
+            "text": "You study a creature\u2019s form and behavior to hypothesize likely means of overcoming its strengths. Once before the end of your next turn, you can use the skill modifier from the triggering check in place of your saving throw modifier against one of the creature\u2019s abilities, in place of your Perception modifier to Seek the creature, in place of your Deception modifier to Feint against the creature, or in place of your Intimidation modifier to Demoralize the creature. Alternatively, against one of the creature\u2019s attacks, you can use your DC for the skill used in the triggering check in place of your AC."
         },
         {
             "name": "Unexpected Shift",
@@ -883,10 +943,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=993",
             "prereq": "\u2014",
             "benefits": "Your supernatural connection sometimes causes you to phase from reality when under threat, disappearing for split seconds before reappearing\u2014often surprising you as much as your enemies.",
-            "text": [
-                "Your supernatural connection sometimes causes you to phase from reality when under threat, disappearing for split seconds before reappearing\u2014often surprising you as much as your enemies. Roll a DC 16 flat check. On a success, you gain resistance to all damage equal to your level against the triggering effect, you gain a +2 circumstance bonus to saving throws against that effect until the start of your turn, and you gain the ",
-                " condition for 1 round."
-            ]
+            "text": "Your supernatural connection sometimes causes you to phase from reality when under threat, disappearing for split seconds before reappearing\u2014often surprising you as much as your enemies. Roll a DC 16 flat check. On a success, you gain resistance to all damage equal to your level against the triggering effect, you gain a +2 circumstance bonus to saving throws against that effect until the start of your turn, and you gain the dazzled condition for 1 round."
         },
         {
             "name": "Vibrant Display",
@@ -897,12 +954,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=994",
             "prereq": "chameleon gnome heritage",
             "benefits": "Whereas most gnomes\u2019 coloration is static or changes slowly, you can cause your hair, eye, and skin color to scintillate in brief and disorienting bursts.",
-            "text": [
-                "Whereas most gnomes\u2019 coloration is static or changes slowly, you can cause your hair, eye, and skin color to scintillate in brief and disorienting bursts. Once every 10 minutes, when you use the ",
-                " action, you can compare your ",
-                " check result to the Perception DCs of all adjacent creatures rather than just one creature within melee reach. It\u2019s possible to get a different degree of success for each target.",
-                " These changes are imprecise and usually short-lived, so while they allow you to periodically change your appearance in unpredictable ways, they are of little use in providing camouflage or aiding a disguise."
-            ]
+            "text": "Whereas most gnomes\u2019 coloration is static or changes slowly, you can cause your hair, eye, and skin color to scintillate in brief and disorienting bursts. Once every 10 minutes, when you use the Feint action, you can compare your Deception check result to the Perception DCs of all adjacent creatures rather than just one creature within melee reach. It\u2019s possible to get a different degree of success for each target. These changes are imprecise and usually short-lived, so while they allow you to periodically change your appearance in unpredictable ways, they are of little use in providing camouflage or aiding a disguise."
         },
         {
             "name": "Animal Elocutionist",
@@ -913,9 +965,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=32",
             "prereq": "Burrow Elocutionist",
             "benefits": "You hear animal sounds as conversations instead of unintelligent noise, and can respond in turn.",
-            "text": [
-                "You hear animal sounds as conversations instead of unintelligent noise, and can respond in turn. You can speak to all animals, not just animals with a burrow Speed. You gain a +1 circumstance bonus to Make an Impression on animals (which usually uses the Diplomacy skill)."
-            ]
+            "text": "You hear animal sounds as conversations instead of unintelligent noise, and can respond in turn. You can speak to all animals, not just animals with a burrow Speed. You gain a +1 circumstance bonus to Make an Impression on animals (which usually uses the Diplomacy skill).\r\n"
         },
         {
             "name": "Eclectic Obsession",
@@ -926,10 +976,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=995",
             "prereq": "Gnome Obsession",
             "benefits": "Your desire for stimulation has led you from one pursuit to another and granted you a smattering of expertise with myriad crafts and professions.",
-            "text": [
-                "Your desire for stimulation has led you from one pursuit to another and granted you a smattering of expertise with myriad crafts and professions. You reflect on snippets you\u2019ve learned to temporarily become trained in one ",
-                " skill of your choice. This proficiency lasts for 10 minutes or until you critically fail a check with that skill. Since this training is temporary, you can\u2019t use it as a prerequisite for a permanent character option like a feat or a skill increase."
-            ]
+            "text": "Your desire for stimulation has led you from one pursuit to another and granted you a smattering of expertise with myriad crafts and professions. You reflect on snippets you\u2019ve learned to temporarily become trained in one Lore skill of your choice. This proficiency lasts for 10 minutes or until you critically fail a check with that skill. Since this training is temporary, you can\u2019t use it as a prerequisite for a permanent character option like a feat or a skill increase."
         },
         {
             "name": "Energized Font",
@@ -940,9 +987,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=33",
             "prereq": "focus pool, at least one innate spell from a gnome heritage or ancestry feat that shares a tradition with at least one of your focus spells",
             "benefits": "The magic within you provides increased energy you can use to focus.",
-            "text": [
-                "The magic within you provides increased energy you can use to focus. You regain 1 Focus Point, up to your usual maximum."
-            ]
+            "text": "The magic within you provides increased energy you can use to focus. You regain 1 Focus Point, up to your usual maximum."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Gnome",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Gnome Weapon Innovator",
@@ -953,9 +1010,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=34",
             "prereq": "Gnome Weapon Familiarity",
             "benefits": "You produce outstanding results when wielding unusual weapons.",
-            "text": [
-                "You produce outstanding results when wielding unusual weapons. Whenever you critically hit using a glaive, kukri, or gnome weapon, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You produce outstanding results when wielding unusual weapons. Whenever you critically hit using a glaive, kukri, or gnome weapon, you apply the weapon's critical specialization effect.\r\n"
         },
         {
             "name": "Intuitive Illusions",
@@ -966,10 +1021,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=996",
             "prereq": "Illusion Sense",
             "benefits": "Illusion magic comes to you so naturally that you can effortlessly sustain your magical ruses.",
-            "text": [
-                "Illusion magic comes to you so naturally that you can effortlessly sustain your magical ruses. You immediately gain the effects of a ",
-                " action to extend the duration of one of your active illusion spells."
-            ]
+            "text": "Illusion magic comes to you so naturally that you can effortlessly sustain your magical ruses. You immediately gain the effects of a Sustain a Spell action to extend the duration of one of your active illusion spells."
         },
         {
             "name": "Natural Illusionist",
@@ -980,12 +1032,33 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=997",
             "prereq": "Illusion Sense",
             "benefits": "By drawing upon the First World\u2019s magic, you can siphon a portion of that malleable world to create a convincing illusion.",
-            "text": [
-                "By drawing upon the First World\u2019s magic, you can siphon a portion of that malleable world to create a convincing illusion. Once per day, you can cast ",
-                ", ",
-                ", or ",
-                ". At 7th level, the spell is heightened to 2nd level, and every 2 levels thereafter, the spell is heightened an additional spell level."
-            ]
+            "text": "By drawing upon the First World\u2019s magic, you can siphon a portion of that malleable world to create a convincing illusion. Once per day, you can cast illusory disguise, item facade, or ventriloquism. At 7th level, the spell is heightened to 2nd level, and every 2 levels thereafter, the spell is heightened an additional spell level."
+        },
+        {
+            "name": "Project Persona",
+            "level": "5",
+            "traits": [
+                "Gnome",
+                "Concentrate",
+                "Illusion",
+                "Primal",
+                "Visual"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1418",
+            "prereq": "\u2014",
+            "benefits": "Where others etch their armor to serve as a conduit for their imaginations, your vivid mind and bold personality allow you to project a more fitting persona over your lackluster armor.",
+            "text": "Where others etch their armor to serve as a conduit for their imaginations, your vivid mind and bold personality allow you to project a more fitting persona over your lackluster armor. You change the shape and appearance of your armor to appear as ordinary or fine clothes of your imagining. The armor's statistics don't change. This effect lasts as long as you remain conscious and are wearing the armor. A creature can disbelieve the illusion by Seeking or touching your armor. The DC equals your Will DC."
+        },
+        {
+            "name": "Cautious Curiosity",
+            "level": "9",
+            "traits": [
+                "Gnome"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1419",
+            "prereq": "at least one arcane or occult innate spell gained from a gnome heritage or gnome ancestry feat",
+            "benefits": "You've learned a few magical techniques for getting yourself both into and out of trouble unnoticed.",
+            "text": "You've learned a few magical techniques for getting yourself both into and out of trouble unnoticed. You gain misdirection and silence as 2nd-level arcane or occult innate spells. The tradition of these spells must match the tradition you use for your gnome ancestry options. You can cast each spell once per day and can target only yourself."
         },
         {
             "name": "First World Adept",
@@ -996,11 +1069,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=35",
             "prereq": "at least one primal innate spell",
             "benefits": "Over time your fey magic has grown stronger.",
-            "text": [
-                "Over time your fey magic has grown stronger. You gain ",
-                " and ",
-                " as 2nd-level primal innate spells. You can cast each of these primal innate spells once per day."
-            ]
+            "text": "Over time your fey magic has grown stronger. You gain faerie fire and invisibility as 2nd-level primal innate spells. You can cast each of these primal innate spells once per day."
         },
         {
             "name": "Fortutious Shift",
@@ -1011,10 +1080,21 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=998",
             "prereq": "Unexpected Shift",
             "benefits": "You have grown more comfortable with your penchant for supernatural disappearance.",
-            "text": [
-                "You have grown more comfortable with your penchant for supernatural disappearance. The flat check DC of your Fortuitous Shift feat decreases to 11, and you are no longer ",
-                " if you succeed."
-            ]
+            "text": "You have grown more comfortable with your penchant for supernatural disappearance. The flat check DC of your Fortuitous Shift feat decreases to 11, and you are no longer dazzled if you succeed."
+        },
+        {
+            "name": "Life Leap",
+            "level": "9",
+            "traits": [
+                "Gnome",
+                "Move",
+                "Necromancy",
+                "Teleportation"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1420",
+            "prereq": "\u2014",
+            "benefits": "You phase through a space that a living creature occupies in a flash, spontaneously appearing on the opposite side of it in a vibrant display of colorful light.",
+            "text": "You phase through a space that a living creature occupies in a flash, spontaneously appearing on the opposite side of it in a vibrant display of colorful light. You move from your current location to another location that's still adjacent to the same living creature, but on the opposite side or corner of the creature's space. To determine whether a position is valid, use the same rules as for flanking: a line through the center of the two spaces must pass through opposite sides or corners of the creature's space. You pass through the creature's life force, appearing in the selected location; this doesn't trigger reactions based on movement. You must be able to see your destination, and you can't move farther than your Speed would allow."
         },
         {
             "name": "Vivacious Conduit",
@@ -1025,9 +1105,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=36",
             "prereq": "\u2014",
             "benefits": "Your connection to the First World has grown, and its positive energy flows into you rapidly.",
-            "text": [
-                "Your connection to the First World has grown, and its positive energy flows into you rapidly. If you rest for 10 minutes, you gain Hit Points equal to your Constitution modifier \u00d7 half your level. This is cumulative with any healing you receive from Treat Wounds."
-            ]
+            "text": "Your connection to the First World has grown, and its positive energy flows into you rapidly. If you rest for 10 minutes, you gain Hit Points equal to your Constitution modifier \u00d7 half your level. This is cumulative with any healing you receive from Treat Wounds.\r\n"
         },
         {
             "name": "Gnome Weapon Expertise",
@@ -1038,9 +1116,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=37",
             "prereq": "Gnome Weapon Familiarity",
             "benefits": "Your gnome affinity blends with your class training, granting you great skill with gnome weapons.",
-            "text": [
-                "Your gnome affinity blends with your class training, granting you great skill with gnome weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the glaive, kukri, and all gnome weapons in which you are trained."
-            ]
+            "text": "Your gnome affinity blends with your class training, granting you great skill with gnome weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the glaive, kukri, and all gnome weapons in which you are trained."
+        },
+        {
+            "name": "Instinctive Obfuscation",
+            "level": "13",
+            "traits": [
+                "Gnome",
+                "Illusion",
+                "Visual"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1421",
+            "prereq": "at least one arcane or occult innate spell gained from a gnome heritage or gnome ancestry feat",
+            "benefits": "The magic within you manifests as a natural reaction to threats.",
+            "text": "The magic within you manifests as a natural reaction to threats. You gain the effects of mirror image but with two images instead of three. The tradition of this action matches the tradition of your gnome ancestry options."
+        },
+        {
+            "name": "Homeward Bound",
+            "level": "17",
+            "traits": [
+                "Gnome"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1422",
+            "prereq": "\u2014",
+            "benefits": "The connection between you and the First World resonates within your body stronger than it does for most gnomes, allowing you to cross the threshold between the Material Plane and the First World.",
+            "text": "The connection between you and the First World resonates within your body stronger than it does for most gnomes, allowing you to cross the threshold between the Material Plane and the First World. You gain plane shift as a primal innate spell. You can cast it twice per week. This can be used only to travel back and forth between the First World and the Material Plane. Due to your body's natural resonance, you can act as the spell focus, and you don't require a tuning fork."
         }
     ],
     " goblinFeats": [
@@ -1053,10 +1153,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=999",
             "prereq": "unbreakable goblin heritage",
             "benefits": "You have a particular elasticity that makes it easy for you to bounce and squish.",
-            "text": [
-                "You have a particular elasticity that makes it easy for you to bounce and squish. You gain the trained proficiency rank in ",
-                " (or another skill of your choice, if you were already trained in Acrobatics). You also gain a +2 circumstance bonus to Acrobatics checks to Tumble Through a foe\u2019s space."
-            ]
+            "text": "You have a particular elasticity that makes it easy for you to bounce and squish. You gain the trained proficiency rank in Acrobatics (or another skill of your choice, if you were already trained in Acrobatics). You also gain a +2 circumstance bonus to Acrobatics checks to Tumble Through a foe\u2019s space."
         },
         {
             "name": "Burn It!",
@@ -1067,9 +1164,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=38",
             "prereq": "\u2014",
             "benefits": "Fire fascinates you.",
-            "text": [
-                "Fire fascinates you. Your spells and alchemical items that deal fire damage gain a status bonus to damage equal to half the spell\u2019s level or one-quarter the item\u2019s level (minimum 1). You also gain a +1 status bonus to any persistent fire damage you deal."
-            ]
+            "text": "Fire fascinates you. Your spells and alchemical items that deal fire damage gain a status bonus to damage equal to half the spell's level or one-quarter the item's level (minimum 1). You also gain a +1 status bonus to any persistent fire damage you deal."
         },
         {
             "name": "City Scavenger",
@@ -1080,11 +1175,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=39",
             "prereq": "\u2014",
             "benefits": "You know that the greatest treasures often look like refuse, and you scoff at those who throw away perfectly good scraps.",
-            "text": [
-                "You know that the greatest treasures often look like refuse, and you scoff at those who throw away perfectly good scraps. You gain a +1 circumstance bonus to checks to Subsist, and you can use Society or Survival when you Subsist in a settlement.",
-                " When you Subsist in a city, you also gather valuable junk that silly longshanks threw away. You can Earn Income using Society or Survival in the same time as you Subsist, without spending any additional days of downtime. You also gain a +1 circumstance bonus to this check.",
-                " If you have the irongut goblin heritage, increase the bonuses to +2."
-            ]
+            "text": "You know that the greatest treasures often look like refuse, and you scoff at those who throw away perfectly good scraps. You gain a +1 circumstance bonus to checks to Subsist, and you can use Society or Survival when you Subsist in a settlement. When you Subsist in a city, you also gather valuable junk that silly longshanks threw away. You can Earn Income using Society or Survival in the same time as you Subsist, without spending any additional days of downtime. You also gain a +1 circumstance bonus to this check.\r\n"
+        },
+        {
+            "name": "Extra Squishy",
+            "level": "1",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1423",
+            "prereq": "unbreakable goblin heritage",
+            "benefits": "Your rubbery physique makes it easier for you to wedge yourself into tight spaces and more difficult for your enemies to dislodge you.",
+            "text": "Your rubbery physique makes it easier for you to wedge yourself into tight spaces and more difficult for your enemies to dislodge you. You become trained in Acrobatics. If you would automatically become trained in Acrobatics (from your background or class, for example), you instead become trained in a skill of your choice. If you roll a success to Squeeze, you get a critical success instead. While you're Squeezing, you gain a +4 circumstance bonus to your Fortitude or Reflex DCs against attempts to Shove you or otherwise move you from your space."
         },
         {
             "name": "Fang Sharpener",
@@ -1095,10 +1197,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1000",
             "prereq": "irongut goblin or razortooth goblin heritage",
             "benefits": "You have filed your teeth into jagged points and have an unusually powerful jaw, making your mouth a dangerous weapon.",
-            "text": [
-                "You have filed your teeth into jagged points and have an unusually powerful jaw, making your mouth a dangerous weapon. If you\u2019re an irongut goblin, you gain a jaws unarmed attack that deals 1d4 piercing damage, and if you\u2019re a razortooth goblin, your jaws unarmed attack deals 1d8 piercing damage and loses the finesse trait. Whenever you score a critical hit with your jaws unarmed attack, your target takes 1 ",
-                " bleed damage per weapon damage die."
-            ]
+            "text": "You have filed your teeth into jagged points and have an unusually powerful jaw, making your mouth a dangerous weapon. If you\u2019re an irongut goblin, you gain a jaws unarmed attack that deals 1d4 piercing damage, and if you\u2019re a razortooth goblin, your jaws unarmed attack deals 1d8 piercing damage and loses the finesse trait. Whenever you score a critical hit with your jaws unarmed attack, your target takes 1 persistent bleed damage per weapon damage die."
         },
         {
             "name": "Goblin Lore",
@@ -1109,9 +1208,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=40",
             "prereq": "\u2014",
             "benefits": "You\u2019ve picked up skills and tales from your goblin community.",
-            "text": [
-                "You\u2019ve picked up skills and tales from your goblin community. You gain the trained proficiency rank in Nature and Stealth. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Goblin Lore."
-            ]
+            "text": "You've picked up skills and tales from your goblin community. You gain the trained proficiency rank in Nature and Stealth. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Goblin Lore.\r\n"
         },
         {
             "name": "Goblin Scuttle",
@@ -1122,9 +1219,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=41",
             "prereq": "\u2014",
             "benefits": "You take advantage of your ally\u2019s movement to adjust your position.",
-            "text": [
-                "You take advantage of your ally\u2019s movement to adjust your position. You Step."
-            ]
+            "text": "You take advantage of your ally\u2019s movement to adjust your position. You Step."
         },
         {
             "name": "Goblin Song",
@@ -1135,12 +1230,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=42",
             "prereq": "\u2014",
             "benefits": "You sing annoying goblin songs, distracting your foes with silly and repetitive lyrics.",
-            "text": [
-                "You sing annoying goblin songs, distracting your foes with silly and repetitive lyrics. Attempt a Performance check against the Will DC of a single enemy within 30 feet. This has all the usual traits and restrictions of a Performance check. You can affect up to two targets within range if you have expert proficiency in Performance, four if you have master proficiency, and eight if you have legendary proficiency.",
-                " The target takes a \u20131 status penalty to Perception checks and Will saves for 1 minute.",
-                " The target takes a \u20131 status penalty to Perception checks and Will saves for 1 round.",
-                " The target is temporarily immune to attempts to use Goblin Song for 1 hour."
-            ]
+            "text": "You sing annoying goblin songs, distracting your foes with silly and repetitive lyrics. Attempt a Performance check against the Will DC of a single enemy within 30 feet. This has all the usual traits and restrictions of a Performance check. You can affect up to two targets within range if you have expert proficiency in Performance, four if you have master proficiency, and eight if you have legendary proficiency.\r\n"
         },
         {
             "name": "Goblin Weapon Familiarity",
@@ -1151,10 +1241,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=43",
             "prereq": "\u2014",
             "benefits": "Others might look upon them with disdain, but you know that the weapons of your people are as effective as they are sharp.",
-            "text": [
-                "Others might look upon them with disdain, but you know that the weapons of your people are as effective as they are sharp. You are trained with the dogslicer and horsechopper.",
-                " In addition, you gain access to all uncommon goblin weapons. For the purpose of determining your proficiency, martial goblin weapons are simple weapons and advanced goblin weapons are martial weapons."
-            ]
+            "text": "Others might look upon them with disdain, but you know that the weapons of your people are as effective as they are sharp. You are trained with the dogslicer and horsechopper. In addition, you gain access to all uncommon goblin weapons. For the purpose of determining your proficiency, martial goblin weapons are simple weapons and advanced goblin weapons are martial weapons.\r\n"
         },
         {
             "name": "Hard Tail",
@@ -1165,9 +1252,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1001",
             "prereq": "tailed goblin heritage",
             "benefits": "Your tail is much stronger than most, and you can lash out with it with the strength of a whip.",
-            "text": [
-                "Your tail is much stronger than most, and you can lash out with it with the strength of a whip. You gain a tail unarmed attack that deals 1d6 bludgeoning damage."
-            ]
+            "text": "Your tail is much stronger than most, and you can lash out with it with the strength of a whip. You gain a tail unarmed attack that deals 1d6 bludgeoning damage."
         },
         {
             "name": "Junk Tinker",
@@ -1178,10 +1263,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=44",
             "prereq": "\u2014",
             "benefits": "You can make useful tools out of even twisted or rusted scraps.",
-            "text": [
-                "You can make useful tools out of even twisted or rusted scraps. When using the Crafting skill to Craft, you can make level 0 items, including weapons but not armor, out of junk. This reduces the Price to one-quarter the usual amount but always results in a shoddy item. Shoddy items normally give a penalty, but you don\u2019t take this penalty when using shoddy items you made.",
-                " You can also incorporate junk to save money while you Craft any item. This grants you a discount on the item as if you had spent 1 additional day working to reduce the cost, but the item is obviously made of junk. At the GM\u2019s discretion, this might affect the item\u2019s resale value depending on the buyer\u2019s tastes."
-            ]
+            "text": "You can make useful tools out of even twisted or rusted scraps. When using the Crafting skill to Craft, you can make level 0 items, including weapons but not armor, out of junk. This reduces the Price to one-quarter the usual amount but always results in a shoddy item. Shoddy items normally give a penalty, but you don't take this penalty when using shoddy items you made. You can also incorporate junk to save money while you Craft any item. This grants you a discount on the item as if you had spent 1 additional day working to reduce the cost, but the item is obviously made of junk. At the GM's discretion, this might affect the item's resale value depending on the buyer's tastes.\r\n"
         },
         {
             "name": "Rough Rider",
@@ -1192,13 +1274,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=45",
             "prereq": "\u2014",
             "benefits": "You are especially good at riding traditional goblin mounts.",
-            "text": [
-                "You are especially good at riding traditional goblin mounts. You gain the ",
-                " feat, even if you don\u2019t meet the prerequisites. You gain a +1 circumstance bonus to Nature checks to use Command an Animal on a ",
-                " or ",
-                " mount. You can always select a wolf as your animal companion, even if you would usually select an animal companion with the mount special ability, such as for a ",
-                "."
-            ]
+            "text": "You are especially good at riding traditional goblin mounts. You gain the Ride feat, even if you don't meet the prerequisites. You gain a +1 circumstance bonus to Nature checks to use Command an Animal on a goblin dog or wolf mount. You can always select a wolf as your animal companion, even if you would usually select an animal companion with the mount special ability, such as for a champion's steed ally.\r\n"
+        },
+        {
+            "name": "Twitchy",
+            "level": "1",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1424",
+            "prereq": "\u2014",
+            "benefits": "You are naturally suspicious and wary of danger, especially when you suspect someone might be leading you into an ambush.",
+            "text": "You are naturally suspicious and wary of danger, especially when you suspect someone might be leading you into an ambush. You gain a +1 circumstance bonus to AC and saves against hazards, and to all of your initiative rolls. If at least one of your opponents is using Deception or Diplomacy to determine their initiative, your bonus to initiative from this feat increases to +4."
         },
         {
             "name": "Very Sneaky",
@@ -1209,9 +1296,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=46",
             "prereq": "\u2014",
             "benefits": "Taller folk rarely pay attention to the shadows at their feet, and you take full advantage of this.",
-            "text": [
-                "Taller folk rarely pay attention to the shadows at their feet, and you take full advantage of this. You can move 5 feet farther when you take the Sneak action, up to your Speed. In addition, as long as you continue to use Sneak actions and succeed at your Stealth check, you don\u2019t become observed if you don\u2019t have cover or greater cover and aren\u2019t concealed at the end of the Sneak action, as long as you have cover or greater cover or are concealed at the end of your turn."
-            ]
+            "text": "Taller folk rarely pay attention to the shadows at their feet, and you take full advantage of this. You can move 5 feet farther when you take the Sneak action, up to your Speed. In addition, as long as you continue to use Sneak actions and succeed at your Stealth check, you don't become observed if you don't have cover or greater cover and aren't concealed at the end of the Sneak action, as long as you have cover or greater cover or are concealed at the end of your turn.\r\n"
         },
         {
             "name": "Ankle Bite",
@@ -1222,9 +1307,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1002",
             "prereq": "Fang Sharpener or razortooth goblin heritage",
             "benefits": "Whenever someone grabs onto you, you instinctively bite down hard.",
-            "text": [
-                "Whenever someone grabs onto you, you instinctively bite down hard. Sometimes that makes them let go, and sometimes it just makes them angrier, but either way, it\u2019s both satisfying and tasty. Make a jaws Strike against the triggering foe. On a critical hit, you are no longer grabbed. This Strike doesn\u2019t count toward your multiple attack penalty, and your multiple attack penalty doesn\u2019t apply to this Strike."
-            ]
+            "text": "Whenever someone grabs onto you, you instinctively bite down hard. Sometimes that makes them let go, and sometimes it just makes them angrier, but either way, it\u2019s both satisfying and tasty. Make a jaws Strike against the triggering foe. On a critical hit, you are no longer grabbed. This Strike doesn\u2019t count toward your multiple attack penalty, and your multiple attack penalty doesn\u2019t apply to this Strike."
         },
         {
             "name": "Chosen of Lamashtu",
@@ -1235,10 +1318,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1003",
             "prereq": "worshipper of Lamashtu",
             "benefits": "You bear the favor and blessings of Lamashtu, the Mother of Monsters.",
-            "text": [
-                "You bear the favor and blessings of ",
-                ", the Mother of Monsters. She has bestowed a mutation upon you, granting you the benefits of another heritage. Choose one goblin heritage that you do not already have; you gain that heritage and its benefits."
-            ]
+            "text": "You bear the favor and blessings of Lamashtu, the Mother of Monsters. She has bestowed a mutation upon you, granting you the benefits of another heritage. Choose one goblin heritage that you do not already have; you gain that heritage and its benefits."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Goblin",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Goblin Weapon Frenzy",
@@ -1249,9 +1341,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=47",
             "prereq": "Goblin Weapon Familiarity",
             "benefits": "You know how to wield your people\u2019s vicious weapons.",
-            "text": [
-                "You know how to wield your people\u2019s vicious weapons. Whenever you score a critical hit using a goblin weapon, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You know how to wield your people's vicious weapons. Whenever you score a critical hit using a goblin weapon, you apply the weapon's critical specialization effect.\r\n"
+        },
+        {
+            "name": "Kneecap",
+            "level": "5",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1425",
+            "prereq": "\u2014",
+            "benefits": "You deliver a punishing blow to an enemy's knee, shin, or other vulnerable anatomy within your reach.",
+            "text": "You deliver a punishing blow to an enemy's knee, shin, or other vulnerable anatomy within your reach. Make a Strike with one of your melee weapons or melee unarmed attacks. This attack doesn't deal damage. On a hit, the target takes a \u201310-foot status penalty to its Speed or a \u201315-foot status penalty on a critical hit. This penalty applies only if the target has a land Speed and depends on legs or other targetable appendages to use its land Speed. As with all penalties to Speed, this can't reduce a creature's Speed below 5 feet."
+        },
+        {
+            "name": "Loud Singer",
+            "level": "5",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1426",
+            "prereq": "Goblin Song",
+            "benefits": "Staying on pitch, proper breath control, and remembering the words are all less important than the real measure of a good singer: volume! The range of your Goblin Song is increased to 60 feet, and you can target one additional enemy when you use it.",
+            "text": "Staying on pitch, proper breath control, and remembering the words are all less important than the real measure of a good singer: volume! The range of your Goblin Song is increased to 60 feet, and you can target one additional enemy when you use it."
         },
         {
             "name": "Tail Spin",
@@ -1262,10 +1374,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1004",
             "prereq": "tailed goblin heritage, Hard Tail ",
             "benefits": "You excel at using your tail as a weapon to upend your foes.",
-            "text": [
-                "You excel at using your tail as a weapon to upend your foes. Attempt a single ",
-                " check to Trip up to two adjacent creatures. If you roll a success against a target, you get a critical success against that target instead."
-            ]
+            "text": "You excel at using your tail as a weapon to upend your foes. Attempt a single Athletics check to Trip up to two adjacent creatures. If you roll a success against a target, you get a critical success against that target instead."
         },
         {
             "name": "Torch Goblin",
@@ -1276,16 +1385,10 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1005",
             "prereq": "charhide goblin heritage",
             "benefits": "You\u2019ve spent enough time on fire that you know how to use it to your advantage.",
-            "text": [
-                "You\u2019ve spent enough time on fire that you know how to use it to your advantage. You can light yourself thoroughly on fire with a held torch, a bottle of ",
-                ", or a similar incendiary, dealing yourself 1d6 persistent fire damage. As long as you are suffering persistent fire damage, all your melee attacks against adjacent creatures deal an additional 1 fire damage per weapon damage die. Any creature that successfully ",
-                ", ",
-                ", or ",
-                " you takes 1d6 fire damage; if it uses a weapon for that action, the weapon takes the damage instead. You must still attempt the flat check to remove the persistent fire damage each round, as normal."
-            ]
+            "text": "You\u2019ve spent enough time on fire that you know how to use it to your advantage. You can light yourself thoroughly on fire with a held torch, a bottle of alchemist\u2019s fire, or a similar incendiary, dealing yourself 1d6 persistent fire damage. As long as you are suffering persistent fire damage, all your melee attacks against adjacent creatures deal an additional 1 fire damage per weapon damage die. Any creature that successfully Grapples, Shoves, or Trips you takes 1d6 fire damage; if it uses a weapon for that action, the weapon takes the damage instead. You must still attempt the flat check to remove the persistent fire damage each round, as normal."
         },
         {
-            "name": "Tree Climber",
+            "name": "Tree Climber (Goblin)",
             "level": "5",
             "traits": [
                 "Goblin"
@@ -1293,10 +1396,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1006",
             "prereq": "tailed goblin or treedweller goblin heritage",
             "benefits": "Your time in forest or jungle canopies has taught you how to scramble across branches with sure feet.",
-            "text": [
-                "Your time in forest or jungle canopies has taught you how to scramble across branches with sure feet. You gain a climb Speed of 10 feet. If you also have the ",
-                " ancestry feat, your total climb Speed increases to your land Speed when climbing trees."
-            ]
+            "text": "Your time in forest or jungle canopies has taught you how to scramble across branches with sure feet. You gain a climb Speed of 10 feet. If you also have the Cave Climber ancestry feat, your total climb Speed increases to your land Speed when climbing trees."
+        },
+        {
+            "name": "Vandal",
+            "level": "5",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1427",
+            "prereq": "\u2014",
+            "benefits": "You have a knack for breaking and dismantling things.",
+            "text": "You have a knack for breaking and dismantling things. Putting them back together is the boring part, so you largely don't bother with that. You become trained in Thievery. If you would automatically become trained in Thievery (from your background or class, for example), you instead become trained in a skill of your choice. In addition, whenever you hit with a Strike against a trap or an unattended object, you ignore the first 5 points of the object's Hardness."
         },
         {
             "name": "Cave Climber",
@@ -1307,9 +1418,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=48",
             "prereq": "\u2014",
             "benefits": "After years of crawling and climbing through caverns, you can climb easily anywhere you go.",
-            "text": [
-                "After years of crawling and climbing through caverns, you can climb easily anywhere you go. You gain a climb Speed of 10 feet."
-            ]
+            "text": "After years of crawling and climbing through caverns, you can climb easily anywhere you go. You gain a climb Speed of 10 feet."
+        },
+        {
+            "name": "Cling",
+            "level": "9",
+            "traits": [
+                "Goblin"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1428",
+            "prereq": "\u2014",
+            "benefits": "You hang onto a foe to harry them into submission.",
+            "text": "You hang onto a foe to harry them into submission. If your target moves while you're hanging onto it, you can choose to move with the target. The target is released if you choose not to move with it, at the start of your next turn, or if the target Escapes. Attempts to Escape from a Cling follow the rules for Escape, but use your Acrobatics DC and end the Cling instead of the conditions normally ended by the Escape action."
         },
         {
             "name": "Freeze It!",
@@ -1320,13 +1440,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1007",
             "prereq": "snow goblin heritage",
             "benefits": "You are no rime hag or Jadwiga, but the magic of the north has still left a mark on you.",
-            "text": [
-                "You are no rime hag or Jadwiga, but the magic of the north has still left a mark on you. Frigid ice runs through your veins, and you can expel frost from your body to freeze your foes. Attempt an ",
-                " check against the Fortitude DC of an adjacent foe. If you have master proficiency in Athletics, you can affect up to two adjacent foes, rolling one Athletics check against each foe.",
-                " The target becomes clumsy 2 for 1 round.",
-                " The target becomes clumsy 1 for 1 round.",
-                " The target is temporarily immune for 1 minute."
-            ]
+            "text": "You are no rime hag or Jadwiga, but the magic of the north has still left a mark on you. Frigid ice runs through your veins, and you can expel frost from your body to freeze your foes. Attempt an Athletics check against the Fortitude DC of an adjacent foe. If you have master proficiency in Athletics, you can affect up to two adjacent foes, rolling one Athletics check against each foe."
         },
         {
             "name": "Hungry Goblin",
@@ -1337,9 +1451,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1008",
             "prereq": "Fang Sharpener",
             "benefits": "You\u2019ll eat anything and anyone.",
-            "text": [
-                "You\u2019ll eat anything and anyone. Whenever you inflict persistent bleed damage with your jaws unarmed attack, you gain temporary Hit Points equal to half your level for 1 minute."
-            ]
+            "text": "You\u2019ll eat anything and anyone. Whenever you inflict persistent bleed damage with your jaws unarmed attack, you gain temporary Hit Points equal to half your level for 1 minute."
         },
         {
             "name": "Roll with It",
@@ -1350,9 +1462,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1009",
             "prereq": "unbreakable goblin heritage, Bouncy Goblin",
             "benefits": "When you take a big hit, your foe bounces you around like a rubber ball, but you escape the worst of the blow.",
-            "text": [
-                "When you take a big hit, your foe bounces you around like a rubber ball, but you escape the worst of the blow. Your foe can move you any distance of its choice up to 30 feet in a direction of its choice (this is not forced movement, and it triggers reactions as normal). You fall prone and are stunned 1. Attempt a DC 6 flat check. On a success, you take minimum damage from the attack, and on a critical success, if the attack was a critical hit, you don\u2019t take double damage from the critical hit."
-            ]
+            "text": "When you take a big hit, your foe bounces you around like a rubber ball, but you escape the worst of the blow. Your foe can move you any distance of its choice up to 30 feet in a direction of its choice (this is not forced movement, and it triggers reactions as normal). You fall prone and are stunned 1. Attempt a DC 6 flat check. On a success, you take minimum damage from the attack, and on a critical success, if the attack was a critical hit, you don\u2019t take double damage from the critical hit."
         },
         {
             "name": "Scalding Spit",
@@ -1363,10 +1473,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1010",
             "prereq": "Torch Goblin",
             "benefits": "Your bodily fluids burn with surprising volatility, as if you ran on oil instead of blood.",
-            "text": [
-                "Your bodily fluids burn with surprising volatility, as if you ran on oil instead of blood. As long as you are taking ",
-                ", you gain a boiling spit ranged unarmed attack with a range of 30 feet that deals 1d6 fire damage."
-            ]
+            "text": "Your bodily fluids burn with surprising volatility, as if you ran on oil instead of blood. As long as you are taking persistent fire damage, you gain a boiling spit ranged unarmed attack with a range of 30 feet that deals 1d6 fire damage."
         },
         {
             "name": "Skittering Scuttle",
@@ -1377,10 +1484,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=49",
             "prereq": "Goblin Scuttle",
             "benefits": "You can scuttle farther and faster when maneuvering alongside allies.",
-            "text": [
-                "You can scuttle farther and faster when maneuvering alongside allies. When you use ",
-                ", you can Stride up to half your Speed instead of Stepping."
-            ]
+            "text": "You can scuttle farther and faster when maneuvering alongside allies. When you use Goblin Scuttle, you can Stride up to half your Speed instead of Stepping."
         },
         {
             "name": "Goblin Weapon Expertise",
@@ -1391,9 +1495,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=50",
             "prereq": "Goblin Weapon Familiarity",
             "benefits": "Your goblin affinity blends with your class training, granting you great skill with goblin weapons.",
-            "text": [
-                "Your goblin affinity blends with your class training, granting you great skill with goblin weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the dogslicer, horsechopper, and all goblin weapons in which you are trained."
-            ]
+            "text": "Your goblin affinity blends with your class training, granting you great skill with goblin weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the dogslicer, horsechopper, and all goblin weapons in which you are trained.\r\n"
         },
         {
             "name": "Unbreakable-er Goblin",
@@ -1404,10 +1506,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1011",
             "prereq": "unbreakable goblin heritage",
             "benefits": "As hard as most unbreakable goblins are to break, you are that much harder to break.",
-            "text": [
-                "As hard as most unbreakable goblins are to break, you are that much harder to break. You gain 20 Hit Points from your ancestry instead of 10. When you fall, you take no falling damage. If you have the ",
-                " feat, after falling or jumping from a height of at least 20 feet, you can bounce back into the air, up to half the distance you fell (and half as far forward if you jumped). These bounces continue until you bounce less than 20 feet."
-            ]
+            "text": "As hard as most unbreakable goblins are to break, you are that much harder to break. You gain 20 Hit Points from your ancestry instead of 10. When you fall, you take no falling damage. If you have the Bouncy Goblin feat, after falling or jumping from a height of at least 20 feet, you can bounce back into the air, up to half the distance you fell (and half as far forward if you jumped). These bounces continue until you bounce less than 20 feet."
         },
         {
             "name": "Very, Very Sneaky",
@@ -1418,9 +1517,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=51",
             "prereq": "Very Sneaky",
             "benefits": "Your ability to hide is so great, you can disappear straight from vision.",
-            "text": [
-                "You can move up to your Speed when you use the Sneak action, and you no longer need to have cover or greater cover or be concealed to Hide or Sneak."
-            ]
+            "text": "You can move up to your Speed when you use the Sneak action, and you no longer need to have cover or greater cover or be concealed to Hide or Sneak."
+        },
+        {
+            "name": "Reckless Abandon (Goblin)",
+            "level": "17",
+            "traits": [
+                "Goblin",
+                "Fortune"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1429",
+            "prereq": "\u2014",
+            "benefits": "Despite a lifetime filled with questionable decisions, you've managed to survive, as though you have uncanny luck that lets you avoid the consequences of your own actions.",
+            "text": "Despite a lifetime filled with questionable decisions, you've managed to survive, as though you have uncanny luck that lets you avoid the consequences of your own actions. For the remainder of your turn, if you roll a failure or critical failure on a saving throw against a harmful effect, you get a success instead. Further, enemies and hazards that would damage you this turn roll the minimum possible damage. These benefits apply only to harmful effects incurred entirely during your turn in which you activate Reckless Abandon, such as running through a prismatic wall. Persistent damage and conditions that were applied prior to your turn proceed normally, and as soon as your turn ends you are subject to the full consequences of any dangers still threatening you."
         }
     ],
     " halfElfFeats": [
@@ -1433,10 +1542,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=66",
             "prereq": "spellcasting class feature",
             "benefits": "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style.",
-            "text": [
-                "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you\u2019re a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class\u2019s tradition.",
-                " If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one."
-            ]
+            "text": "Through study of multiple magical traditions, you've altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you're a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class's tradition. If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one.\r\n"
+        },
+        {
+            "name": "Ancestral Linguistics",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1407",
+            "prereq": "at least 100 years old",
+            "benefits": "Over your extensive lifespan, you've studied many languages.",
+            "text": "Over your extensive lifespan, you've studied many languages. During your daily preparations, you can recede into old memories to become fluent in one common language or one other language you have access to. You know this language until you prepare again. Since this knowledge is temporary, you can't use it as a prerequisite for a permanent character option."
         },
         {
             "name": "Ancestral Longevity",
@@ -1447,30 +1564,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=12",
             "prereq": "at least 100 years old",
             "benefits": "You have accumulated a vast array of lived knowledge over the years.",
-            "text": [
-                "You have accumulated a vast array of lived knowledge over the years. During your daily preparations, you can reflect upon your life experiences to gain the trained proficiency rank in one skill of your choice. This proficiency lasts until you prepare again. Since this proficiency is temporary, you can\u2019t use it as a prerequisite for a skill increase or a permanent character option like a feat."
-            ]
+            "text": "You have accumulated a vast array of lived knowledge over the years. During your daily preparations, you can reflect upon your life experiences to gain the trained proficiency rank in one skill of your choice. This proficiency lasts until you prepare again. Since this proficiency is temporary, you can\u2019t use it as a prerequisite for a skill increase or a permanent character option like a feat."
         },
         {
             "name": "Arcane Tattoos",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=938",
             "prereq": "\u2014",
             "benefits": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic.",
-            "text": [
-                "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (",
-                "), conjuration (",
-                "), enchantment (",
-                "), evocation (",
-                "), illusion (",
-                "), necromancy (",
-                "), or transmutation (",
-                "). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
-            ]
+            "text": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (shield), conjuration (tanglefoot), enchantment (daze), evocation (electric arc), illusion (ghost sound), necromancy (chill touch), or transmutation (sigil). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
         },
         {
             "name": "Cooperative Nature",
@@ -1481,42 +1587,32 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=67",
             "prereq": "\u2014",
             "benefits": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness.",
-            "text": [
-                "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid."
-            ]
+            "text": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid.\r\n"
         },
         {
-            "name": "Courteous Comback",
+            "name": "Courteous Comeback",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=939",
             "prereq": "\u2014",
             "benefits": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit.",
-            "text": [
-                "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
-            ]
+            "text": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
         },
         {
             "name": "Devil's Advocate",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=940",
             "prereq": "\u2014",
             "benefits": "You know more about the habits of devils than is entirely safe.",
-            "text": [
-                "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against ",
-                " and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a ",
-                " check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.",
-                " If you have the ",
-                " skill feat, you don\u2019t take the penalty to your immediate Diplomacy check if the target is a devil."
-            ]
+            "text": "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against devils and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result."
         },
         {
             "name": "Dragon Spit",
@@ -1527,13 +1623,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=941",
             "prereq": "Tian-Dan ethnicity",
             "benefits": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage.",
-            "text": [
-                "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: ",
-                ", ",
-                ", ",
-                ", or ",
-                ". You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
-            ]
+            "text": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: acid splash, electric arc, produce flame, or ray of frost. You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
+        },
+        {
+            "name": "Earned Glory",
+            "level": "1",
+            "traits": [
+                "Half-Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1444",
+            "prereq": "\u2014",
+            "benefits": "Elves are often skeptical of their half-elven kin, and you are experienced at telling stories of your accomplishments to gain their respect.",
+            "text": "Elves are often skeptical of their half-elven kin, and you are experienced at telling stories of your accomplishments to gain their respect. You are trained in Performance. If you would automatically become trained in Performance (from your background or class, for example), you instead become trained in a skill of your choice. You gain the Impressive Performance feat. When you attempt a Performance check to Make an Impression on an elf, if you roll a critical failure, you get a failure instead."
         },
         {
             "name": "Elemental Wrath",
@@ -1544,11 +1645,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=975",
             "prereq": "\u2014",
             "benefits": "You are so attuned to the land that you can call forth a bolt of energy from your surroundings.",
-            "text": [
-                "You are so attuned to the land that you can call forth a bolt of energy from your surroundings. When you gain this feat, select acid, cold, electricity, or fire. You can call to the land to cast the ",
-                " cantrip as an innate primal spell at will, except the spell has only verbal components and deals the type of damage you chose instead of acid damage; the spell gains the trait appropriate to its damage instead of the ",
-                " trait. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "You are so attuned to the land that you can call forth a bolt of energy from your surroundings. When you gain this feat, select acid, cold, electricity, or fire. You can call to the land to cast the acid splash cantrip as an innate primal spell at will, except the spell has only verbal components and deals the type of damage you chose instead of acid damage; the spell gains the trait appropriate to its damage instead of the acid trait. A cantrip is heightened to a spell level equal to half your level rounded up."
         },
         {
             "name": "Elf Atavism",
@@ -1559,10 +1656,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=79",
             "prereq": "\u2014",
             "benefits": "Your elven blood runs particularly strong, granting you features far more elven than those of a typical half-elf.",
-            "text": [
-                "Your elven blood runs particularly strong, granting you features far more elven than those of a typical half-elf. You may also have been raised among elves, steeped in your elven ancestors\u2019 heritage. You gain the benefits of the elf heritage of your elven parent or ancestors. You typically can\u2019t select a heritage that depends on or improves an elven feature you don\u2019t have. For example, you couldn\u2019t gain the cavern elf\u2019s darkvision ability if you didn\u2019t have low-light vision. In these cases, at the GM\u2019s discretion, you might gain a different benefit.",
-                " You can take this feat only at 1st level, and you can\u2019t retrain out of this feat or into this feat."
-            ]
+            "text": "Your elven blood runs particularly strong, granting you features far more elven than those of a typical half-elf. You may also have been raised among elves, steeped in your elven ancestors' heritage. You gain the benefits of the elf heritage of your elven parent or ancestors. You typically can't select a heritage that depends on or improves an elven feature you don't have. For example, you couldn't gain the cavern elf's darkvision ability if you didn't have low-light vision. In these cases, at the GM's discretion, you might gain a different benefit.\r\n"
+        },
+        {
+            "name": "Elven Aloofness",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1408",
+            "prereq": "\u2014",
+            "benefits": "As much as you might care for them, you've come to terms with the ephemeral nature of non-elves, and it makes their threats feel less troublesome.",
+            "text": "As much as you might care for them, you've come to terms with the ephemeral nature of non-elves, and it makes their threats feel less troublesome. If a non-elf rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (and thus can't try to Coerce you again for 1 week). When a non-elf attempts to Demoralize you, you become temporarily immune for 1 day, instead of 10 minutes."
         },
         {
             "name": "Elven Lore",
@@ -1573,9 +1678,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=13",
             "prereq": "\u2014",
             "benefits": "You\u2019ve studied in traditional elven arts, learning about arcane magic and the world around you.",
-            "text": [
-                "You\u2019ve studied in traditional elven arts, learning about arcane magic and the world around you. You gain the trained proficiency rank in Arcana and Nature. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Elven Lore."
-            ]
+            "text": "You've studied in traditional elven arts, learning about arcane magic and the world around you. You gain the trained proficiency rank in Arcana and Nature. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Elven Lore.\r\n"
         },
         {
             "name": "Elven Verve",
@@ -1586,13 +1689,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=976",
             "prereq": "\u2014",
             "benefits": "While all elves are immune to the paralyzing touch of ghouls, you can shake off flesh-numbing magic of all kinds.",
-            "text": [
-                "While all elves are immune to the paralyzing touch of ",
-                ", you can shake off flesh-numbing magic of all kinds. You gain a +1 circumstance bonus to saves against effects that would impose the ",
-                ", ",
-                ", or ",
-                " conditions. When you would be immobilized, paralyzed, or slowed for at least 2 rounds, reduce that duration by 1 round."
-            ]
+            "text": "While all elves are immune to the paralyzing touch of ghouls, you can shake off flesh-numbing magic of all kinds. You gain a +1 circumstance bonus to saves against effects that would impose the immobilized, paralyzed, or slowed conditions. When you would be immobilized, paralyzed, or slowed for at least 2 rounds, reduce that duration by 1 round."
         },
         {
             "name": "Elven Weapon Familiarity",
@@ -1603,10 +1700,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=14",
             "prereq": "\u2014",
             "benefits": "You favor bows and other elegant weapons.",
-            "text": [
-                "You favor bows and other elegant weapons. You are trained with longbows, composite longbows, longswords, rapiers, shortbows, and composite shortbows.",
-                " In addition, you gain access to all uncommon elf weapons. For the purpose of determining your proficiency, martial elf weapons are simple weapons and advanced elf weapons are martial weapons."
-            ]
+            "text": "You favor bows and other elegant weapons. You are trained with longbows, composite longbows, longswords, rapiers, shortbows, and composite shortbows. In addition, you gain access to all uncommon elf weapons. For the purpose of determining your proficiency, martial elf weapons are simple weapons and advanced elf weapons are martial weapons.\r\n"
         },
         {
             "name": "Forlorn",
@@ -1617,9 +1711,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=15",
             "prereq": "\u2014",
             "benefits": "Watching your friends age and die fills you with moroseness that protects you against harmful emotions.",
-            "text": [
-                "Watching your friends age and die fills you with moroseness that protects you against harmful emotions. You gain a +1 circumstance bonus to saving throws against emotion effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead."
-            ]
+            "text": "Watching your friends age and die fills you with moroseness that protects you against harmful emotions. You gain a +1 circumstance bonus to saving throws against emotion effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead.\r\n"
         },
         {
             "name": "General Training",
@@ -1630,10 +1722,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=68",
             "prereq": "\u2014",
             "benefits": "Your adaptability manifests in your mastery of a range of useful abilities.",
-            "text": [
-                "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat\u2019s prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.",
-                " You can select this feat multiple times, choosing a different feat each time."
-            ]
+            "text": "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat's prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.\r\n"
         },
         {
             "name": "Gloomseer",
@@ -1644,10 +1733,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=942",
             "prereq": "Nidalese ethnicity",
             "benefits": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light.",
-            "text": [
-                "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain ",
-                "."
-            ]
+            "text": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain low-light vision."
         },
         {
             "name": "Haughty Obstinacy",
@@ -1658,40 +1744,43 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=69",
             "prereq": "\u2014",
             "benefits": "Your powerful ego makes it harder for others to order you around.",
-            "text": [
-                "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can\u2019t try to Coerce you again for 1 week)."
-            ]
+            "text": "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can't try to Coerce you again for 1 week).\r\n"
         },
         {
             "name": "Keep Up Appearances",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=943",
             "prereq": "\u2014",
             "benefits": "Taldan pride means you never show weakness.",
-            "text": [
-                "Taldan pride means you never show weakness. Roll a ",
-                " check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a ",
-                " effect, it can\u2019t use its Feed on Fear ability on you."
-            ]
+            "text": "Taldan pride means you never show weakness. Roll a Deception check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a fear effect, it can\u2019t use its Feed on Fear ability on you."
         },
         {
             "name": "Know Oneself",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=944",
             "prereq": "\u2014",
             "benefits": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge.",
-            "text": [
-                "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
-            ]
+            "text": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
+        },
+        {
+            "name": "Know Your Own",
+            "level": "1",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1409",
+            "prereq": "\u2014",
+            "benefits": "You've spent countless hours studying the history of elves on your world and beyond and are a studied expert in your people's ways.",
+            "text": "You've spent countless hours studying the history of elves on your world and beyond and are a studied expert in your people's ways. If you critically fail a check to Recall Knowledge about elves, elven society, or elven history, you get a failure instead."
         },
         {
             "name": "Natural Ambition",
@@ -1702,9 +1791,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=70",
             "prereq": "\u2014",
             "benefits": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field.",
-            "text": [
-                "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
-            ]
+            "text": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
         },
         {
             "name": "Natural Skill",
@@ -1715,9 +1802,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=71",
             "prereq": "\u2014",
             "benefits": "Your ingenuity allows you to learn a wide variety of skills.",
-            "text": [
-                "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
-            ]
+            "text": "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
         },
         {
             "name": "Nimble Elf",
@@ -1728,9 +1813,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=16",
             "prereq": "\u2014",
             "benefits": "Your muscles are tightly honed.",
-            "text": [
-                "Your muscles are tightly honed. Your Speed increases by 5 feet."
-            ]
+            "text": "Your muscles are tightly honed. Your Speed increases by 5 feet."
         },
         {
             "name": "Otherworldly Magic",
@@ -1741,25 +1824,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=17",
             "prereq": "\u2014",
             "benefits": "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic.",
-            "text": [
-                "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic. Choose one cantrip from the ",
-                " spell list. You can cast this cantrip as an arcane innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "Your elven magic manifests as a simple arcane spell, even if you aren\u2019t formally trained in magic. Choose one cantrip from the arcane spell list. You can cast this cantrip as an arcane innate spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
         },
         {
             "name": "Quah Bond",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=945",
             "prereq": "\u2014",
             "benefits": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance.",
-            "text": [
-                "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the ",
-                " skill feat in that skill, as the spirits\u2019 help guides your actions. "
-            ]
+            "text": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the Assurance skill feat in that skill, as the spirits\u2019 help guides your actions. Lyrune-Quah Religion Shadde-Quah Athletics Shriikirri-Quah Nature Shundar-Quah Diplomacy Sklar-Quah Intimidation Skoan-Quah Medicine Tamiir-Quah Acrobatics"
         },
         {
             "name": "Round Ears",
@@ -1770,26 +1847,20 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=960",
             "prereq": "\u2014",
             "benefits": "Your elven lineage is subtle enough that you look barely different from other humans, and you\u2019ve learned to use that to your advantage.",
-            "text": [
-                "Your elven lineage is subtle enough that you look barely different from other humans, and you\u2019ve learned to use that to your advantage. You gain the trained proficiency rank in ",
-                " (or another skill of your choice, if you were already trained in Deception). You gain a +4 circumstance bonus to Impersonate checks to pretend you aren\u2019t a half-elf. Observers are never granted circumstance bonuses to Perception checks due to you Impersonating a full-blooded human, and you never take circumstance penalties due to you Impersonating a full-blooded human.",
-                " You can take this feat only at 1st level, and you can\u2019t retrain out of this feat or into this feat."
-            ]
+            "text": "Your elven lineage is subtle enough that you look barely different from other humans, and you\u2019ve learned to use that to your advantage. You gain the trained proficiency rank in Deception (or another skill of your choice, if you were already trained in Deception). You gain a +4 circumstance bonus to Impersonate checks to pretend you aren\u2019t a half-elf. Observers are never granted circumstance bonuses to Perception checks due to you Impersonating a full-blooded human, and you never take circumstance penalties due to you Impersonating a full-blooded human."
         },
         {
             "name": "Saoc Astrology",
             "level": "1",
             "traits": [
                 "Human",
-                " Concentrate",
-                " Uncommon"
+                "Concentrate",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=946",
             "prereq": "\u2014",
             "benefits": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy.",
-            "text": [
-                "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
-            ]
+            "text": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
         },
         {
             "name": "Share Thoughts",
@@ -1800,10 +1871,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=977",
             "prereq": "Mualijae, Ilverani, or Vourinoi ethnicity",
             "benefits": "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers.",
-            "text": [
-                "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers. You can cast ",
-                " as an innate occult spell once per day, but you can target only other elves or half-elves."
-            ]
+            "text": "You have an uncanny knack of communicating with other elves without speaking, though this habit that is often uncomfortable to observers. You can cast mindlink as an innate occult spell once per day, but you can target only other elves or half-elves."
         },
         {
             "name": "Sociable",
@@ -1814,26 +1882,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=961",
             "prereq": "\u2014",
             "benefits": "You\u2019re extremely extroverted, and you often spend your time carousing or otherwise socializing.",
-            "text": [
-                "You\u2019re extremely extroverted, and you often spend your time carousing or otherwise socializing. You are trained in ",
-                " (or another skill of your choice if you were already trained in Diplomacy), and you gain the ",
-                " skill feat."
-            ]
+            "text": "You\u2019re extremely extroverted, and you often spend your time carousing or otherwise socializing. You are trained in Diplomacy (or another skill of your choice if you were already trained in Diplomacy), and you gain the Hobnobber skill feat."
         },
         {
             "name": "Tupilaq Carver",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=947",
             "prereq": "You have a spellcasting class feature with the divine or primal tradition",
             "benefits": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance.",
-            "text": [
-                "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the ",
-                " spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
-            ]
+            "text": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the summon construct spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
         },
         {
             "name": "Unconventional Weaponry",
@@ -1844,10 +1905,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=72",
             "prereq": "\u2014",
             "benefits": "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture.",
-            "text": [
-                "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon.",
-                " If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon."
-            ]
+            "text": "You've familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon. If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon.\r\n"
         },
         {
             "name": "Unwavering Mien",
@@ -1858,56 +1916,43 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=18",
             "prereq": "\u2014",
             "benefits": "Your mystic control and meditations allow you to resist external influences upon your consciousness.",
-            "text": [
-                "Your mystic control and meditations allow you to resist external influences upon your consciousness. Whenever you are affected by a mental effect that lasts at least 2 rounds, you can reduce the duration by 1 round.",
-                " You still require natural sleep, but you treat your saving throws against effects that would cause you to fall asleep as one degree of success better. This protects only against sleep effects, not against other forms of falling unconscious."
-            ]
+            "text": "Your mystic control and meditations allow you to resist external influences upon your consciousness. Whenever you are affected by a mental effect that lasts at least 2 rounds, you can reduce the duration by 1 round. You still require natural sleep, but you treat your saving throws against effects that would cause you to fall asleep as one degree of success better. This protects only against sleep effects, not against other forms of falling unconscious.\r\n"
         },
         {
             "name": "Viking Shieldbearer",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=948",
             "prereq": "\u2014",
             "benefits": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself.",
-            "text": [
-                "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the ",
-                " reaction and are trained in your choice of the battle axe or longsword."
-            ]
+            "text": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the Shield Block reaction and are trained in your choice of the battle axe or longsword."
         },
         {
             "name": "Wildborn Magic",
             "level": "1",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=978",
             "prereq": "\u2014",
             "benefits": "You have learned to access the old magic of wild places.",
-            "text": [
-                "You have learned to access the old magic of wild places. Choose one cantrip from the ",
-                " spell list. You can cast this cantrip as an innate primal spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
-            ]
+            "text": "You have learned to access the old magic of wild places. Choose one cantrip from the primal spell list. You can cast this cantrip as an innate primal spell at will. A cantrip is heightened to a spell level equal to half your level rounded up."
         },
         {
             "name": "Witch Warden",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=949",
             "prereq": "\u2014",
             "benefits": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant.",
-            "text": [
-                "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against ",
-                ", and to saving throws against spells cast by a witch or ",
-                ". If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
-            ]
+            "text": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against curses, and to saving throws against spells cast by a witch or hag. If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
         },
         {
             "name": "Woodcraft",
@@ -1918,10 +1963,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=979",
             "prereq": "\u2014",
             "benefits": "You have a innate familiarity with forested areas.",
-            "text": [
-                "You have a innate familiarity with forested areas. When in a forest or jungle environment, if you roll a critical failure on a ",
-                " skill check to Sense Direction, Subsist, or Cover Tracks, you get a failure instead, and if you roll a success, you get a critical success instead."
-            ]
+            "text": "You have a innate familiarity with forested areas. When in a forest or jungle environment, if you roll a critical failure on a Survival skill check to Sense Direction, Subsist, or Cover Tracks, you get a failure instead, and if you roll a success, you get a critical success instead."
         },
         {
             "name": "Adaptive Adept",
@@ -1932,10 +1974,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=73",
             "prereq": "Adapted Cantrip, can cast 3rd-level spells",
             "benefits": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition.",
-            "text": [
-                "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from ",
-                ". You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
-            ]
+            "text": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from Adapted Cantrip. You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
         },
         {
             "name": "Ageless Patience",
@@ -1946,10 +1985,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=19",
             "prereq": "\u2014",
             "benefits": "You work at a pace born from longevity that enhances your thoroughness.",
-            "text": [
-                "You work at a pace born from longevity that enhances your thoroughness. You can voluntarily spend twice as much time as normal on a Perception check or skill check to gain a +2 circumstance bonus to that check. You also don\u2019t treat a natural 1 as worse than usual on these checks; you get a critical failure only if your result is 10 lower than the DC. For example, you could get these benefits if you spent 2 actions to Seek, which normally takes 1 action. You can get these benefits during exploration by taking twice as long exploring as normal, or in downtime by spending twice as much downtime.",
-                " The GM might determine a situation doesn\u2019t grant you a benefit if a delay would be directly counterproductive to your success, such as a tense negotiation with an impatient creature."
-            ]
+            "text": "You work at a pace born from longevity that enhances your thoroughness. You can voluntarily spend twice as much time as normal on a Perception check or skill check to gain a +2 circumstance bonus to that check. You also don't treat a natural 1 as worse than usual on these checks; you get a critical failure only if your result is 10 lower than the DC. For example, you could get these benefits if you spent 2 actions to Seek, which normally takes 1 action. You can get these benefits during exploration by taking twice as long exploring as normal, or in downtime by spending twice as much downtime. The GM might determine a situation doesn't grant you a benefit if a delay would be directly counterproductive to your success, such as a tense negotiation with an impatient creature.\r\n"
+        },
+        {
+            "name": "Ancestral Suspicion",
+            "level": "5",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1410",
+            "prereq": "\u2014",
+            "benefits": "Long-lived elves have seen civilizations rise and fall, often at the hands of outside forces.",
+            "text": "Long-lived elves have seen civilizations rise and fall, often at the hands of outside forces. As a result, they have developed a wariness of others who might seek to influence or control them. You've been trained to resist such manipulation, gaining a +2 circumstance bonus to saving throws against effects that would make you controlled, such as dominate, and to Perception checks to Sense Motive when trying to determine if a creature is under the influence of such an effect. When you roll a success on a saving throw against such an effect, you get a critical success instead."
         },
         {
             "name": "Clever Improviser",
@@ -1960,10 +2007,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=74",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned how to handle situations when you\u2019re out of your depth.",
-            "text": [
-                "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the ",
-                " general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
-            ]
+            "text": "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the Untrained Improvisation general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
         },
         {
             "name": "Darkseer",
@@ -1974,29 +2018,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=950",
             "prereq": "Gloomseer",
             "benefits": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness.",
-            "text": [
-                " smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain ",
-                "."
-            ]
+            "text": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain darkvision."
         },
         {
             "name": "Defiance Unto Death",
             "level": "5",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=980",
             "prereq": "\u2014",
             "benefits": "You loathe the alghollthus and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation.",
-            "text": [
-                "You loathe the ",
-                " and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation. If you would start your turn ",
-                ", ",
-                ", or ",
-                " due to a failed Will save, you can attempt a Will save against the same DC; on a success, you become ",
-                " until your next turn, rather than act against your will."
-            ]
+            "text": "You loathe the alghollthus and their mind magic, and you\u2019ve been trained to be willing to die rather than give into mental manipulation. If you would start your turn confused, controlled, or fleeing due to a failed Will save, you can attempt a Will save against the same DC; on a success, you become paralyzed until your next turn, rather than act against your will."
         },
         {
             "name": "Elven Instincts",
@@ -2007,9 +2041,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=981",
             "prereq": "\u2014",
             "benefits": "Your senses let you react rapidly.",
-            "text": [
-                "Your senses let you react rapidly. You gain a +2 circumstance bonus to Perception checks made as initiative rolls. Additionally, if your initiative roll result is tied with that of an opponent, you go first, regardless of whether you rolled Perception or not."
-            ]
+            "text": "Your senses let you react rapidly. You gain a +2 circumstance bonus to Perception checks made as initiative rolls. Additionally, if your initiative roll result is tied with that of an opponent, you go first, regardless of whether you rolled Perception or not."
         },
         {
             "name": "Elven Weapon Elegance",
@@ -2020,10 +2052,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=20",
             "prereq": "Elven Weapon Familiarity",
             "benefits": "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them.",
-            "text": [
-                "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them. Whenever you critically hit using an elf weapon or one of the weapons listed in ",
-                ", you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You are attuned to the weapons of your elven ancestors and are particularly deadly when using them. Whenever you critically hit using an elf weapon or one of the weapons listed in Elven Weapon Familiarity, you apply the weapon's critical specialization effect.\r\n"
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Forest Stealth",
@@ -2034,10 +2074,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=982",
             "prereq": "Expert in Stealth",
             "benefits": "You are skilled at quickly hiding behind bits of underbrush or foliage.",
-            "text": [
-                "You are skilled at quickly hiding behind bits of underbrush or foliage. You ",
-                " and then use that cover to Hide."
-            ]
+            "text": "You are skilled at quickly hiding behind bits of underbrush or foliage. You Take Cover and then use that cover to Hide."
         },
         {
             "name": "Inspire Imitation",
@@ -2048,9 +2085,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=80",
             "prereq": "\u2014",
             "benefits": "Your own actions inspire your allies to great achievements.",
-            "text": [
-                "Your own actions inspire your allies to great achievements. Whenever you critically succeed at a skill check, you automatically qualify to use the Aid reaction when attempting to help an ally using the same skill, even without spending an action to prepare to do so."
-            ]
+            "text": "Your own actions inspire your allies to great achievements. Whenever you critically succeed at a skill check, you automatically qualify to use the Aid reaction when attempting to help an ally using the same skill, even without spending an action to prepare to do so.\r\n"
+        },
+        {
+            "name": "Martial Experience",
+            "level": "5",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1411",
+            "prereq": "\u2014",
+            "benefits": "You've crossed blades with a wide variety of foes wielding a wide variety of weapons, and you've learned the basics of fighting with nearly any of them.",
+            "text": "You've crossed blades with a wide variety of foes wielding a wide variety of weapons, and you've learned the basics of fighting with nearly any of them. When wielding a weapon you aren't proficient with, treat your level as your proficiency bonus. At 11th level, you become trained in all weapons."
         },
         {
             "name": "Ornate Tattoo",
@@ -2061,10 +2107,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=951",
             "prereq": "Arcane Tattoos",
             "benefits": "You expand your tattoos to encompass greater magic.",
-            "text": [
-                "You expand your tattoos to encompass greater magic. Choose a 1st-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "You expand your tattoos to encompass greater magic. Choose a 1st-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Sense Allies",
+            "level": "5",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1437",
+            "prereq": "\u2014",
+            "benefits": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others.",
+            "text": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others. Willing allies that you are aware of within 60 feet that would otherwise be undetected by you are instead hidden from you. The flat check for you to target willing allies within 60 feet that are hidden from you is 5 instead of 11."
         },
         {
             "name": "Supernatural Charm",
@@ -2075,10 +2129,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=81",
             "prereq": "\u2014",
             "benefits": "The elven magic in your blood manifests as a force you can use to become more appealing or alluring.",
-            "text": [
-                "The elven magic in your blood manifests as a force you can use to become more appealing or alluring. You can cast 1st-level ",
-                " as an arcane innate spell once per day."
-            ]
+            "text": "The elven magic in your blood manifests as a force you can use to become more appealing or alluring. You can cast 1st-level charm as an arcane innate spell once per day."
         },
         {
             "name": "Wavetouched Paragon",
@@ -2089,11 +2140,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=952",
             "prereq": "Bonuwat ethnicity",
             "benefits": "You have been blessed by the sea, granting you the ability to swim like a fish.",
-            "text": [
-                "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed.",
-                " If you have the ",
-                " background, you can take this feat at 1st level instead of 5th."
-            ]
+            "text": "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed."
         },
         {
             "name": "Wildborn Adept",
@@ -2104,12 +2151,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=983",
             "prereq": "Wildborn Magic",
             "benefits": "The whispers of the jungle grant you more diverse access to simple primal magic.",
-            "text": [
-                "The whispers of the jungle grant you more diverse access to simple primal magic. You can cast ",
-                ", ",
-                ", and ",
-                " as innate primal spells at will. If you chose one of those spells with Wildborn Magic, you can select a new spell for Wildborn Magic."
-            ]
+            "text": "The whispers of the jungle grant you more diverse access to simple primal magic. You can cast dancing lights, disrupt undead, and tanglefoot as innate primal spells at will. If you chose one of those spells with Wildborn Magic, you can select a new spell for Wildborn Magic."
         },
         {
             "name": "Brightness Seeker",
@@ -2120,16 +2162,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=984",
             "prereq": "\u2014",
             "benefits": "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast augury as an innate divine spell.",
-            "text": [
-                "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast ",
-                " as an innate divine spell. Unless the result of the ",
-                " was \u201cnothing,\u201d you gain the following reaction for the next 30 minutes:",
-                " ",
-                " You attempt an attack roll, skill check, or saving throw while performing the course of action from your ",
-                ", but you haven\u2019t rolled yet",
-                "You gain a +1 status bonus to the triggering check, or a +2 status bonus if the result of the ",
-                " was \u201cwoe\u201d and you proceeded anyway."
-            ]
+            "text": "Once per day, you can spend 10 minutes studying your surroundings in search of omens related to a particular course of action to cast augury as an innate divine spell. Unless the result of the augury was \u201cnothing,\u201d you gain the following reaction for the next 30 minutes:"
         },
         {
             "name": "Cooperative Soul",
@@ -2140,9 +2173,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=75",
             "prereq": "Cooperative Nature",
             "benefits": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them.",
-            "text": [
-                "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success."
-            ]
+            "text": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success.\r\n"
         },
         {
             "name": "Dragon Prince",
@@ -2153,10 +2184,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=953",
             "prereq": "Dragon Spit",
             "benefits": "The blood of the Dragon Kings runs strong in your veins.",
-            "text": [
-                "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the ",
-                " sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
-            ]
+            "text": "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the dragon breath sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
         },
         {
             "name": "Elf Step",
@@ -2167,9 +2195,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=21",
             "prereq": "\u2014",
             "benefits": "You move in a graceful dance, and even your steps are broad.",
-            "text": [
-                "You move in a graceful dance, and even your steps are broad. You Step 5 feet twice."
-            ]
+            "text": "You move in a graceful dance, and even your steps are broad. You Step 5 feet twice."
         },
         {
             "name": "Expert Longevity",
@@ -2180,11 +2206,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=22",
             "prereq": "Ancestral Longevity",
             "benefits": "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life.",
-            "text": [
-                "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life. When you choose a skill in which to become trained with ",
-                ", you can also choose a skill in which you are already trained and become an expert in that skill. This lasts until your Ancestral Longevity expires.",
-                " When the effects of Ancestral Longevity and Expert Longevity expire, you can retrain one of your skill increases. The skill increase you gain from this retraining must either make you trained in the skill you chose with Ancestral Longevity or make you an expert in the skill you chose with Expert Longevity."
-            ]
+            "text": "You\u2019ve continued to refine the knowledge and skills you\u2019ve gained through your life. When you choose a skill in which to become trained with Ancestral Longevity, you can also choose a skill in which you are already trained and become an expert in that skill. This lasts until your Ancestral Longevity expires. When the effects of Ancestral Longevity and Expert Longevity expire, you can retrain one of your skill increases. The skill increase you gain from this retraining must either make you trained in the skill you chose with Ancestral Longevity or make you an expert in the skill you chose with Expert Longevity."
+        },
+        {
+            "name": "Group Aid",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1438",
+            "prereq": "\u2014",
+            "benefits": "Your upbringing emphasized teamwork and helping your allies comes naturally to you.",
+            "text": "Your upbringing emphasized teamwork and helping your allies comes naturally to you. After you Aid an ally at a skill check that doesn't have the attack trait, you can also Aid any other ally who attempts the same skill check for the same purpose that round. You do so as a free action rather than a reaction. The preparation you did to help must still apply to the other allies, and you can Aid each ally only once. For example, if you helped lift up an ally to Aid them on an Athletics check to scale a wall, you could keep the same posture to give a boost to other allies attempting to scale the wall in the same round."
+        },
+        {
+            "name": "Hardy Traveler",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1439",
+            "prereq": "\u2014",
+            "benefits": "There's no journey too far or burden too heavy when your friends are at your side.",
+            "text": "There's no journey too far or burden too heavy when your friends are at your side. Increase your maximum and encumbered Bulk limits by 1. In addition, you gain a +10-foot circumstance bonus to your Speed during overland travel."
         },
         {
             "name": "Heir of the Saoc",
@@ -2195,9 +2239,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=954",
             "prereq": "Saoc Astrology",
             "benefits": "In the past, you would have been a proud initiate of the Saoc Brethren.",
-            "text": [
-                "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
-            ]
+            "text": "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
         },
         {
             "name": "Incredible Improvisation",
@@ -2208,9 +2250,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=76",
             "prereq": "Clever Improviser",
             "benefits": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience.",
-            "text": [
-                "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
-            ]
+            "text": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
         },
         {
             "name": "Multitalented",
@@ -2221,25 +2261,41 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=77",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned to split your focus between multiple classes with ease.",
-            "text": [
-                "You\u2019ve learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat (for more about multiclass archetypes, see page 219), even if you normally couldn\u2019t take another dedication feat until you take more feats from your current archetype.",
-                " If you\u2019re a half-elf, you don\u2019t need to meet the feat\u2019s ability score prerequisites."
-            ]
+            "text": "You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype. If you're a half-elf, you don't need to meet the feat's ability score prerequisites.\r\n"
+        },
+        {
+            "name": "Otherworldly Acumen",
+            "level": "9",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1412",
+            "prereq": "at least one innate spell gained from an elf ancestry feat",
+            "benefits": "The arcane magic you possess grows in power and complexity.",
+            "text": "The arcane magic you possess grows in power and complexity. Choose one common 2nd-level spell from the same tradition as an innate spell you previously gained from another elf ancestry feat (from the arcane list if you have Otherworldly Magic, for example). You can cast that spell as an innate spell once per day, using the same tradition as the list you chose the spell from. Your magic is adaptable. By spending 1 day of downtime, you can change the spell you chose to a different common 2nd-level spell from the same tradition."
+        },
+        {
+            "name": "Pinch Time",
+            "level": "9",
+            "traits": [
+                "Half-Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1445",
+            "prereq": "\u2014",
+            "benefits": "One of your parents has a human life span and another an elven life span, with your own somewhere between.",
+            "text": "One of your parents has a human life span and another an elven life span, with your own somewhere between. As a result, you have an unusual perspective on time, which you've learned to manifest to aid yourself in moments of stress. You gain haste as a 3rd-level arcane innate spell, though you can target only yourself. You can Cast this Spell once per day."
         },
         {
             "name": "Sense Thoughts",
             "level": "9",
             "traits": [
                 "Elf",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=985",
             "prereq": "Share Thoughts",
             "benefits": "You have an even stranger knack for knowing what other people are thinking.",
-            "text": [
-                "You have an even stranger knack for knowing what other people are thinking. You can cast ",
-                " as an innate occult spell once per day."
-            ]
+            "text": "You have an even stranger knack for knowing what other people are thinking. You can cast mind reading as an innate occult spell once per day."
         },
         {
             "name": "Shory Aeromancer",
@@ -2250,13 +2306,21 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=955",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity",
             "benefits": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you.",
-            "text": [
-                "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level ",
-                " on yourself as an innate arcane spell once per day."
-            ]
+            "text": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level fly on yourself as an innate arcane spell once per day."
         },
         {
-            "name": "Virtue-Forged Tattooed",
+            "name": "Tree Climber (Elf)",
+            "level": "9",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1413",
+            "prereq": "\u2014",
+            "benefits": "You've spent much of your life among the treetops and have become an expert at quickly and safely climbing them.",
+            "text": "You've spent much of your life among the treetops and have become an expert at quickly and safely climbing them. You gain a climb Speed of 10 feet."
+        },
+        {
+            "name": "Virtue-Forged Tattoos",
             "level": "9",
             "traits": [
                 "Human"
@@ -2264,10 +2328,41 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=956",
             "prereq": "Ornate Tattoo",
             "benefits": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin.",
-            "text": [
-                "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Advanced General Training",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1440",
+            "prereq": "\u2014",
+            "benefits": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities.",
+            "text": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities. You gain a general feat of 7th level or lower. You must meet the feat's prerequisites."
+        },
+        {
+            "name": "Avenge Ally",
+            "level": "13",
+            "traits": [
+                "Elf",
+                "Fortune"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1414",
+            "prereq": "\u2014",
+            "benefits": "Though you know that you will eventually outlive your companions, seeing them at death's door brings clarity to your attacks.",
+            "text": "Though you know that you will eventually outlive your companions, seeing them at death's door brings clarity to your attacks. Make a Strike. Roll twice on the attack roll and use the higher result."
+        },
+        {
+            "name": "Bounce Back",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1441",
+            "prereq": "\u2014",
+            "benefits": "You recover from near-death experiences with astounding resilience.",
+            "text": "You recover from near-death experiences with astounding resilience. Don't increase the value of your wounded condition due to losing the dying condition."
         },
         {
             "name": "Elven Weapon Expertise",
@@ -2278,9 +2373,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=24",
             "prereq": "Elven Weapon Familiarity",
             "benefits": "Your elven affinity blends with your class training, granting you great skill with elven weapons.",
-            "text": [
-                "Your elven affinity blends with your class training, granting you great skill with elven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all elf weapons in which you are trained."
-            ]
+            "text": "Your elven affinity blends with your class training, granting you great skill with elven weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in longbows, composite longbows, longswords, rapiers, shortbows, composite shortbows, and all elf weapons in which you are trained."
         },
         {
             "name": "Irriseni Ice-Witch",
@@ -2291,10 +2384,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=957",
             "prereq": "Jadwiga ethnicity, wintertouched human heritage",
             "benefits": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself.",
-            "text": [
-                "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level ",
-                " as an innate arcane spell once per day."
-            ]
+            "text": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level wall of ice as an innate arcane spell once per day."
         },
         {
             "name": "Shadow Pact",
@@ -2305,11 +2395,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=958",
             "prereq": "Nidalese ethnicity",
             "benefits": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon.",
-            "text": [
-                "Thousands of years ago, your ancestors made a pact with ",
-                ". He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level ",
-                " as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
-            ]
+            "text": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon. He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level creation as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
         },
         {
             "name": "Shory Aerialist",
@@ -2320,10 +2406,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=959",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity; Shory Aeromancer or ability to cast fly",
             "benefits": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air.",
-            "text": [
-                "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to ",
-                " checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
-            ]
+            "text": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to Acrobatics checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
+        },
+        {
+            "name": "Stubborn Persistence",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1442",
+            "prereq": "\u2014",
+            "benefits": "Humans are renowned for their ability to persist through the most grueling of trials.",
+            "text": "Humans are renowned for their ability to persist through the most grueling of trials. When you would become fatigued, attempt a DC 17 flat check. On a success, you aren't fatigued. If the fatigued condition has an underlying cause that you don't address, such as lack of rest, you must attempt the check again at an interval determined by the GM until you fail the flat check or address the underlying cause."
         },
         {
             "name": "Unconventional Expertise",
@@ -2334,10 +2428,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=78",
             "prereq": "Unconventional Weaponry, trained in the weapon you chose for Unconventional Weaponry",
             "benefits": "You\u2019ve continued to advance your powers using your unconventional weapon.",
-            "text": [
-                "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for ",
-                "."
-            ]
+            "text": "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for Unconventional Weaponry."
         },
         {
             "name": "Universal Longevity",
@@ -2348,11 +2439,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=23",
             "prereq": "Expert Longevity",
             "benefits": "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life.",
-            "text": [
-                "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life, so you\u2019re almost never truly untrained at a skill. You reflect on your life experiences, changing the skills you selected with ",
-                " and ",
-                "."
-            ]
+            "text": "You\u2019ve perfected your ability to keep up with all the skills you\u2019ve learned over your long life, so you\u2019re almost never truly untrained at a skill. You reflect on your life experiences, changing the skills you selected with Ancestral Longevity and Expert Longevity."
         },
         {
             "name": "Wandering Heart",
@@ -2363,12 +2450,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=986",
             "prereq": "arctic elf, cavern elf, desert elf, woodland elf, or any other elf heritage based on adapting to an environment",
             "benefits": "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves.",
-            "text": [
-                "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves. After spending a week in an environment associated with an elf heritage (such as snow for arctic elf, or a forest or jungle for woodland elf) your heritage automatically changes to become that heritage. This never causes you to change to an elf heritage that isn\u2019t related to an environment, such as ",
-                ", ",
-                ", or ",
-                "."
-            ]
+            "text": "While all elves adapt to their environments over time, you have traveled so widely and become attuned to so many environs that your body now changes more rapidly than other elves. After spending a week in an environment associated with an elf heritage (such as snow for arctic elf, or a forest or jungle for woodland elf) your heritage automatically changes to become that heritage. This never causes you to change to an elf heritage that isn\u2019t related to an environment, such as ancient elf, seer elf, or whisper elf."
+        },
+        {
+            "name": "Heroic Presence",
+            "level": "17",
+            "traits": [
+                "Human",
+                "Emotion",
+                "Mental"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1443",
+            "prereq": "\u2014",
+            "benefits": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve.",
+            "text": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve. You grant up to 10 willing creatures within 30 feet the effects of a 6th-level zealous conviction, though the effect automatically ends on a target if you give that target a command they would normally find repugnant. This action has the auditory trait or visual trait, depending on how you inspire your allies."
+        },
+        {
+            "name": "Magic Rider",
+            "level": "17",
+            "traits": [
+                "Elf"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1415",
+            "prereq": "\u2014",
+            "benefits": "Your people used powerful magic to travel between distant worlds, and the remnants of that magic make such transportation easier for you.",
+            "text": "Your people used powerful magic to travel between distant worlds, and the remnants of that magic make such transportation easier for you. When you are the target of a teleportation spell that transports more than one person, it can affect an additional person beyond the normal limit, chosen by the caster. Additionally, when you're the target of a teleport spell, you and the other targets arrive no farther than 1 mile off target, regardless of distance traveled."
         }
     ],
     " halflingFeats": [
@@ -2377,15 +2483,12 @@
             "level": "1",
             "traits": [
                 "Halfling",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1012",
             "prereq": "\u2014",
             "benefits": "You\u2019ve fiddled with knots, locks, and blacksmith\u2019s puzzles since you were a child to give your hands something to do.",
-            "text": [
-                "You\u2019ve fiddled with knots, locks, and blacksmith\u2019s puzzles since you were a child to give your hands something to do. You gain the trained proficiency rank in ",
-                " (or another skill of your choice, if you\u2019re already trained in Thievery). If you roll a success on a Thievery check to Pick a Lock, you get a critical success instead."
-            ]
+            "text": "You\u2019ve fiddled with knots, locks, and blacksmith\u2019s puzzles since you were a child to give your hands something to do. You gain the trained proficiency rank in Thievery (or another skill of your choice, if you\u2019re already trained in Thievery). If you roll a success on a Thievery check to Pick a Lock, you get a critical success instead."
         },
         {
             "name": "Distracting Shadows",
@@ -2396,9 +2499,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=52",
             "prereq": "\u2014",
             "benefits": "You have learned to remain hidden by using larger folk as a distraction to avoid drawing attention to yourself.",
-            "text": [
-                "You have learned to remain hidden by using larger folk as a distraction to avoid drawing attention to yourself. You can use creatures that are at least one size larger than you (usually Medium or larger) as cover for the Hide and Sneak actions, though you still can\u2019t use such creatures as cover for other uses, such as the Take Cover action."
-            ]
+            "text": "You have learned to remain hidden by using larger folk as a distraction to avoid drawing attention to yourself. You can use creatures that are at least one size larger than you (usually Medium or larger) as cover for the Hide and Sneak actions, though you still can't use such creatures as cover for other uses, such as the Take Cover action.\r\n"
+        },
+        {
+            "name": "Folksy Patter",
+            "level": "1",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1430",
+            "prereq": "\u2014",
+            "benefits": "You are adept at disguising coded messages as folksy idioms.",
+            "text": "You are adept at disguising coded messages as folksy idioms. Using slang, jokes, halfling loanwords, and the like, you convey a simple message consisting of three basic words (such as \u201cDanger assassin flee\u201d or \u201cMeet me moonrise\u201d). Your intended listener can attempt a Perception check to discern the message (DC 20 if an ally, DC 15 if a halfling ally, DC 10 if a halfling ally with Folksy Patter). Eavesdroppers can also attempt a Perception check against your Deception DC to discern your meaning. Any bonuses or penalties to Perception checks to Sense Motive apply."
         },
         {
             "name": "Halfling Lore",
@@ -2409,23 +2521,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=53",
             "prereq": "\u2014",
             "benefits": "You\u2019ve dutifully learned important skills passed down through generations of halfling tradition.",
-            "text": [
-                "You\u2019ve dutifully learned how to keep your balance and how to stick to the shadows where it\u2019s safe, important skills passed down through generations of halfling tradition. You gain the trained proficiency rank in Acrobatics and Stealth. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Halfling Lore."
-            ]
+            "text": "You've dutifully learned how to keep your balance and how to stick to the shadows where it's safe, important skills passed down through generations of halfling tradition. You gain the trained proficiency rank in Acrobatics and Stealth. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Halfling Lore.\r\n"
         },
         {
             "name": "Halfling Luck",
             "level": "1",
             "traits": [
                 "Halfling",
-                " Fortune"
+                "Fortune"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=54",
             "prereq": "\u2014",
             "benefits": "Your happy-go-lucky nature makes it seem like misfortune avoids you.",
-            "text": [
-                "Your happy-go-lucky nature makes it seem like misfortune avoids you, and to an extent, that might even be true. You can reroll the triggering check, but you must use the new result, even if it\u2019s worse than your first roll."
-            ]
+            "text": "Your happy-go-lucky nature makes it seem like misfortune avoids you, and to an extent, that might even be true. You can reroll the triggering check, but you must use the new result, even if it\u2019s worse than your first roll."
         },
         {
             "name": "Halfling Weapon Familiarity",
@@ -2436,10 +2544,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=55",
             "prereq": "\u2014",
             "benefits": "You favor traditional halfling weapons, so you\u2019ve learned how to use them more effectively.",
-            "text": [
-                "You favor traditional halfling weapons, so you\u2019ve learned how to use them more effectively. You have the trained proficiency with the sling, halfling sling staff, and shortsword.",
-                " In addition, you gain access to all uncommon halfling weapons. For you, martial halfling weapons are simple weapons, and advanced halfling weapons are martial weapons."
-            ]
+            "text": "You favor traditional halfling weapons, so you've learned how to use them more effectively. You have the trained proficiency with the sling, halfling sling staff, and shortsword. You gain access to all uncommon halfling weapons. For the purpose of determining your proficiency, martial halfling weapons are simple weapons and advanced halfling weapons are martial weapons."
         },
         {
             "name": "Innocuous",
@@ -2450,25 +2555,30 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1013",
             "prereq": "\u2014",
             "benefits": "Halflings have been unobtrusive assistants of larger folk for untold ages, and your people count on this assumption of innocence.",
-            "text": [
-                "Halflings have been unobtrusive assistants of larger folk for untold ages, and your people count on this assumption of innocence. You gain the trained proficiency rank in ",
-                " (or another skill of your choice, if you\u2019re already trained in Deception). If you fail a Deception check to Create a Diversion, humanoid creatures aren\u2019t aware that you were trying to trick them unless you get a critical failure on your roll."
-            ]
+            "text": "Halflings have been unobtrusive assistants of larger folk for untold ages, and your people count on this assumption of innocence. You gain the trained proficiency rank in Deception (or another skill of your choice, if you\u2019re already trained in Deception). If you fail a Deception check to Create a Diversion, humanoid creatures aren\u2019t aware that you were trying to trick them unless you get a critical failure on your roll."
         },
         {
             "name": "Intuitive Cooperation",
             "level": "1",
             "traits": [
                 "Halfling",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1014",
             "prereq": "\u2014",
             "benefits": "You are accustomed to working alongside others, relying on each other to get by.",
-            "text": [
-                "You are accustomed to working alongside others, relying on each other to get by. You gain a +2 circumstance bonus to checks to ",
-                ", and your allies gain a +2 circumstance bonus to checks to Aid you."
-            ]
+            "text": "You are accustomed to working alongside others, relying on each other to get by. You gain a +2 circumstance bonus to checks to Aid, and your allies gain a +2 circumstance bonus to checks to Aid you."
+        },
+        {
+            "name": "Prairie Rider",
+            "level": "1",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1431",
+            "prereq": "\u2014",
+            "benefits": "You grew up riding your clan's shaggy ponies and riding dogs.",
+            "text": "You grew up riding your clan's shaggy ponies and riding dogs. You become trained in Nature. If you would automatically become trained in Nature (from your background or class, for example), you instead become trained in a skill of your choice. You also get a +1 circumstance bonus to Command an Animal if the target is a traditional halfling mount, such as a pony or riding dog."
         },
         {
             "name": "Sure Feet",
@@ -2479,9 +2589,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=56",
             "prereq": "\u2014",
             "benefits": "Whether keeping your balance or scrambling up a tricky climb, your hairy, calloused feet easily find purchase.",
-            "text": [
-                "Whether keeping your balance or scrambling up a tricky climb, your hairy, calloused feet easily find purchase. If you roll a success on an Acrobatics check to Balance or an Athletics check to Climb, you get a critical success instead. You\u2019re not flat-footed when you attempt to Balance or Climb."
-            ]
+            "text": "Whether keeping your balance or scrambling up a tricky climb, your hairy, calloused feet easily find purchase. If you roll a success on an Acrobatics check to Balance or an Athletics check to Climb, you get a critical success instead. You're not flat-footed when you attempt to Balance or Climb.\r\n"
         },
         {
             "name": "Titan Slinger",
@@ -2492,24 +2600,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=57",
             "prereq": "\u2014",
             "benefits": "You have learned how to use your sling to fell enormous creatures.",
-            "text": [
-                "You have learned how to use your sling to fell enormous creatures. When you hit on an attack with a sling against a Large or larger creature, increase the size of the weapon damage die by one step (details on increasing weapon damage die sizes can be found ",
-                ")."
-            ]
+            "text": "You have learned how to use your sling to fell enormous creatures. When you hit on an attack with a sling against a Large or larger creature, increase the size of the weapon damage die by one step (details on increasing weapon damage die sizes can be found here).\r\n"
         },
         {
             "name": "Unassuming Dedication",
             "level": "1",
             "traits": [
                 "Halfling",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1015",
             "prereq": "\u2014",
             "benefits": "Your family instilled the values of care and patience into you from a young age.",
-            "text": [
-                "Your family instilled the values of care and patience into you from a young age. You gain a +1 circumstance bonus to checks to perform a downtime activity."
-            ]
+            "text": "Your family instilled the values of care and patience into you from a young age. You gain a +1 circumstance bonus to checks to perform a downtime activity."
         },
         {
             "name": "Unfettered Halfling",
@@ -2520,9 +2623,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=58",
             "prereq": "\u2014",
             "benefits": "You were forced into service as a laborer, but you\u2019ve since escaped and have trained to ensure you\u2019ll never be caught again.",
-            "text": [
-                "You were forced into service as a laborer, either pressed into indentured servitude or shackled by the evils of slavery, but you\u2019ve since escaped and have trained to ensure you\u2019ll never be caught again. Whenever you roll a success on a check to Escape or a saving throw against an effect that would impose the grabbed or restrained condition on you, you get a critical success instead. Whenever a creature rolls a failure on a check to Grapple you, they get a critical failure instead. If a creature uses the Grab ability on you, it must succeed at an Athletics check to grab you instead of automatically grabbing you."
-            ]
+            "text": "You were forced into service as a laborer, either pressed into indentured servitude or shackled by the evils of slavery, but you've since escaped and have trained to ensure you'll never be caught again. Whenever you roll a success on a check to Escape or a saving throw against an effect that would impose the grabbed or restrained condition on you, you get a critical success instead. Whenever a creature rolls a failure on a check to Grapple you, they get a critical failure instead. If a creature uses the Grab ability on you, it must succeed at an Athletics check to grab you instead of automatically grabbing you.\r\n"
         },
         {
             "name": "Watchful Halfling",
@@ -2533,11 +2634,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=59",
             "prereq": "\u2014",
             "benefits": "Your communal lifestyle causes you to pay close attention to the people around you.",
-            "text": [
-                "Your communal lifestyle causes you to pay close attention to the people around you, allowing you to more easily notice when they act out of character. You gain a +2 circumstance bonus to Perception checks when using the Sense Motive basic action to notice enchanted or possessed characters. If you aren\u2019t actively using Sense Motive on an enchanted or possessed character, the GM rolls a secret check, without the usual circumstance and with a \u20132 circumstance penalty, for you to potentially notice the enchantment or possession anyway.",
-                " In addition to using it for skill checks, you can use the Aid basic action to grant a bonus to another creature\u2019s saving throw or other check to overcome enchantment or possession.",
-                " As usual for Aid, you need to prepare by using an action on your turn to encourage the creature to fight against the effect."
-            ]
+            "text": "Your communal lifestyle causes you to pay close attention to the people around you, allowing you to more easily notice when they act out of character. You gain a +2 circumstance bonus to Perception checks when using the Sense Motive basic action to notice enchanted or possessed characters. If you aren't actively using Sense Motive on an enchanted or possessed character, the GM rolls a secret check, without the usual circumstance and with a \u20132 circumstance penalty, for you to potentially notice the enchantment or possession anyway. In addition to using it for skill checks, you can use the Aid basic action to grant a bonus to another creature's saving throw or other check to overcome enchantment or possession. As usual for Aid, you need to prepare by using an action on your turn to encourage the creature to fight against the effect.\r\n"
         },
         {
             "name": "Cultural Adaptability",
@@ -2548,26 +2645,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=60",
             "prereq": "\u2014",
             "benefits": "During your adventures, you\u2019ve honed your ability to adapt to the culture of the predominant ancestry around you.",
-            "text": [
-                "During your adventures, you\u2019ve honed your ability to adapt to the culture of the predominant ancestry around you. You gain the ",
-                " general feat, and you also gain one 1st-level ancestry feat from the ancestry you chose for the Adopted Ancestry feat."
-            ]
+            "text": "During your adventures, you've honed your ability to adapt to the culture of the predominant ancestry around you. You gain the Adopted Ancestry general feat, and you also gain one 1st-level ancestry feat from the ancestry you chose for the Adopted Ancestry feat.\r\n"
         },
         {
             "name": "Easily Dismissed",
             "level": "5",
             "traits": [
                 "Halfling",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1016",
             "prereq": "\u2014",
             "benefits": "You are practiced at blending into the background of the streets and halls of larger folk to ensure that you are overlooked.",
-            "text": [
-                "You are practiced at blending into the background of the streets and halls of larger folk to ensure that you are overlooked. When you are in a crowd or well trafficked urban area, you can attempt to ",
-                " and ",
-                ", even when observed. On a success, you aren\u2019t hidden or undetected, but other creatures simply don\u2019t take particular notice of you, even though they can see you. You can\u2019t use this ability on observers who have already seen you perform obtrusive or notable actions. If you perform any action other than to Hide or Sneak or otherwise take particularly salient actions (GM\u2019s discretion), observers notice you right away."
-            ]
+            "text": "You are practiced at blending into the background of the streets and halls of larger folk to ensure that you are overlooked. When you are in a crowd or well trafficked urban area, you can attempt to Hide and Sneak, even when observed. On a success, you aren\u2019t hidden or undetected, but other creatures simply don\u2019t take particular notice of you, even though they can see you. You can\u2019t use this ability on observers who have already seen you perform obtrusive or notable actions. If you perform any action other than to Hide or Sneak or otherwise take particularly salient actions (GM\u2019s discretion), observers notice you right away."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Halfling",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Halfling Ingenuity",
@@ -2578,9 +2680,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1017",
             "prereq": "Halfling Luck",
             "benefits": "While your willingness to dig into a task you know little about might get you into trouble, your incredible luck often saves you from danger.",
-            "text": [
-                "While your willingness to dig into a task you know little about might get you into trouble, your incredible luck often saves you from danger. You can attempt skill actions that normally require you to be trained even if you aren\u2019t trained in that skill. If you use Halfling Luck when you fail a check for a skill with which you are untrained, you can add a proficiency bonus equal to your level, rather than 0, when you reroll the triggering skill check. You gain a +4 circumstance bonus to this rerolled skill check."
-            ]
+            "text": "While your willingness to dig into a task you know little about might get you into trouble, your incredible luck often saves you from danger. You can attempt skill actions that normally require you to be trained even if you aren\u2019t trained in that skill. If you use Halfling Luck when you fail a check for a skill with which you are untrained, you can add a proficiency bonus equal to your level, rather than 0, when you reroll the triggering skill check. You gain a +4 circumstance bonus to this rerolled skill check."
         },
         {
             "name": "Halfling Weapon Trickster",
@@ -2591,12 +2691,10 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=61",
             "prereq": "Halfling Weapon Familiarity",
             "benefits": "You are particularly adept at fighting with your people\u2019s favored weapons.",
-            "text": [
-                "You are particularly adept at fighting with your people\u2019s favored weapons. Whenever you critically succeed at an attack roll using a shortsword, a sling, or a halfling weapon, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You are particularly adept at fighting with your people's favored weapons. Whenever you critically succeed at an attack roll using a shortsword, a sling, or a halfling weapon, you apply the weapon's critical specialization effect.\r\n"
         },
         {
-            "name": "Shared Luck",
+            "name": "Shared Luck (Halfling)",
             "level": "5",
             "traits": [
                 "Halfling"
@@ -2604,10 +2702,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1018",
             "prereq": "Halfling Luck",
             "benefits": "You are evidence that it\u2019s lucky to travel with a halfling.",
-            "text": [
-                "You are evidence that it\u2019s lucky to travel with a halfling. You can use Halfling Luck when an ally within 30 feet fails a skill check or a saving throw to allow the ally to reroll the triggering check instead of you rerolling your own failed check. As usual, your ally must use the new result, even if it\u2019s worse than their first roll. If you have ",
-                ", you can\u2019t use Guiding Luck\u2019s effect that applies to attack rolls and Perception checks to use Shared Luck to benefit an ally."
-            ]
+            "text": "You are evidence that it\u2019s lucky to travel with a halfling. You can use Halfling Luck when an ally within 30 feet fails a skill check or a saving throw to allow the ally to reroll the triggering check instead of you rerolling your own failed check. As usual, your ally must use the new result, even if it\u2019s worse than their first roll. If you have Guiding Luck, you can\u2019t use Guiding Luck\u2019s effect that applies to attack rolls and Perception checks to use Shared Luck to benefit an ally."
+        },
+        {
+            "name": "Step Lively",
+            "level": "5",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1432",
+            "prereq": "\u2014",
+            "benefits": "You are an expert at avoiding the lumbering footsteps of larger creatures.",
+            "text": "You are an expert at avoiding the lumbering footsteps of larger creatures. You Step to another space adjacent to the enemy."
         },
         {
             "name": "Cunning Climber",
@@ -2618,10 +2724,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1019",
             "prereq": "\u2014",
             "benefits": "Whether you are climbing a ship\u2019s rigging, a jungle tree, or a clock tower, you have an uncanny knack for finding footholds and handholds where larger creatures can\u2019t.",
-            "text": [
-                "Whether you are climbing a ship\u2019s rigging, a jungle tree, or a clock tower, you have an uncanny knack for finding footholds and handholds where larger creatures can\u2019t. You gain a climb Speed of 10 feet. You can take the Legendary Climber feat even if you don\u2019t have the ",
-                " feat, provided you meet its other prerequisites."
-            ]
+            "text": "Whether you are climbing a ship\u2019s rigging, a jungle tree, or a clock tower, you have an uncanny knack for finding footholds and handholds where larger creatures can\u2019t. You gain a climb Speed of 10 feet. You can take the Legendary Climber feat even if you don\u2019t have the Quick Climb feat, provided you meet its other prerequisites."
+        },
+        {
+            "name": "Dance Underfoot",
+            "level": "9",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1433",
+            "prereq": "Step Lively",
+            "benefits": "You dart under the legs of your enemies in combat.",
+            "text": "You dart under the legs of your enemies in combat. You can end a successful Tumble Through action in a Large or larger enemy's space. Also, when using the Step Lively feat, you can Step into the triggering enemy's space. The enemy must have limbs or otherwise leave you enough room for this maneuver, as determined by the GM. For instance, you could share space with a giant or dragon, but not an ooze."
         },
         {
             "name": "Fade Away",
@@ -2632,13 +2746,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1020",
             "prereq": "Easily Dismissed",
             "benefits": "Your ability to blend into the background allows you to fade away entirely or appear innocuous even to magical effects.",
-            "text": [
-                "Your ability to blend into the background allows you to fade away entirely or appear innocuous even to magical effects. You gain ",
-                " and ",
-                " as 2nd-level innate occult spells. You can target only yourself with ",
-                ", and you must be the primary target of ",
-                ". You can cast each spell once per day."
-            ]
+            "text": "Your ability to blend into the background allows you to fade away entirely or appear innocuous even to magical effects. You gain invisibility and misdirection as 2nd-level innate occult spells. You can target only yourself with invisibility, and you must be the primary target of misdirection. You can cast each spell once per day."
         },
         {
             "name": "Guiding Luck",
@@ -2649,10 +2757,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=62",
             "prereq": "Halfling Luck",
             "benefits": "Your luck guides you to look the right way and aim your blows unerringly.",
-            "text": [
-                "Your luck guides you to look the right way and aim your blows unerringly. You can use ",
-                " twice per day: once in response to its normal trigger, and once when you fail a Perception check or attack roll instead of the normal trigger."
-            ]
+            "text": "Your luck guides you to look the right way and aim your blows unerringly. You can use Halfling Luck twice per day: once in response to its normal trigger, and once when you fail a Perception check or attack roll instead of the normal trigger."
         },
         {
             "name": "Helpful Halfling",
@@ -2663,10 +2768,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1021",
             "prereq": "\u2014",
             "benefits": "When you aid a friend with a task, you find many ways to help and avoid interfering.",
-            "text": [
-                "When you aid a friend with a task, you find many ways to help and avoid interfering. On a critical success to ",
-                ", you grant your ally a +3 circumstance bonus if you have expert proficiency in the skill (rather than +2), and you grant your ally a +4 circumstance bonus if you have master proficiency (rather than +3). If you roll a critical failure on a check to Aid, you don\u2019t give your ally a \u20131 circumstance penalty to their check."
-            ]
+            "text": "When you aid a friend with a task, you find many ways to help and avoid interfering. On a critical success to Aid, you grant your ally a +3 circumstance bonus if you have expert proficiency in the skill (rather than +2), and you grant your ally a +4 circumstance bonus if you have master proficiency (rather than +3). If you roll a critical failure on a check to Aid, you don\u2019t give your ally a \u20131 circumstance penalty to their check."
         },
         {
             "name": "Irrepressible",
@@ -2677,9 +2779,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=63",
             "prereq": "\u2014",
             "benefits": "You are easily able to ward off attempts to play on your fears and emotions.",
-            "text": [
-                "You are easily able to ward off attempts to play on your fears and emotions. When you roll a success on a saving throw against an emotion effect, you get a critical success instead. If your heritage is gutsy halfling, when you roll a critical failure on a saving throw against an emotion effect, you get a failure instead."
-            ]
+            "text": "You are easily able to ward off attempts to play on your fears and emotions. When you roll a success on a saving throw against an emotion effect, you get a critical success instead. If your heritage is gutsy halfling, when you roll a critical failure on a saving throw against an emotion effect, you get a failure instead.\r\n"
+        },
+        {
+            "name": "Unhampered Passage",
+            "level": "9",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1434",
+            "prereq": "\u2014",
+            "benefits": "You won't allow others to restrain you.",
+            "text": "You won't allow others to restrain you. You can cast freedom of movement on yourself as a primal innate spell once per day."
         },
         {
             "name": "Ceaseless Shadows",
@@ -2690,9 +2801,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=64",
             "prereq": "Distracting Shadows",
             "benefits": "You excel at going unnoticed, especially among a crowd.",
-            "text": [
-                "You excel at going unnoticed, especially among a crowd. You no longer need to have cover or be concealed to Hide or Sneak. If you would have lesser cover from creatures, you gain cover and can Take Cover, and if you would have cover from creatures, you gain greater cover."
-            ]
+            "text": "You excel at going unnoticed, especially among a crowd. You no longer need to have cover or be concealed to Hide or Sneak. If you would have lesser cover from creatures, you gain cover and can Take Cover, and if you would have cover from creatures, you gain greater cover.\r\n"
         },
         {
             "name": "Cobble Dancer",
@@ -2703,9 +2812,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1022",
             "prereq": "\u2014",
             "benefits": "You know how to take advantage of foes thrown off-balance by unstable flooring, loose cobblestones, or similar impediments.",
-            "text": [
-                "You know how to take advantage of foes thrown off-balance by unstable flooring, loose cobblestones, or similar impediments. While in an outdoor urban environment, you can Step into difficult terrain and enemies in difficult terrain are flat-footed to you."
-            ]
+            "text": "You know how to take advantage of foes thrown off-balance by unstable flooring, loose cobblestones, or similar impediments. While in an outdoor urban environment, you can Step into difficult terrain and enemies in difficult terrain are flat-footed to you."
         },
         {
             "name": "Halfling Weapon Expertise",
@@ -2716,12 +2823,10 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=65",
             "prereq": "Halfling, Weapon Familiarity",
             "benefits": "Your halfling affinity blends with your class training, granting you great skill with halfling weapons.",
-            "text": [
-                "Your halfling affinity blends with your class training, granting you great skill with halfling weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the sling, halfling sling staff, shortsword, and all halfling weapons in which you are trained."
-            ]
+            "text": "Your halfling affinity blends with your class training, granting you great skill with halfling weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the sling, halfling sling staff, shortsword, and all halfling weapons in which you are trained."
         },
         {
-            "name": "Incredible Luck",
+            "name": "Incredible Luck (Halfling)",
             "level": "13",
             "traits": [
                 "Halfling"
@@ -2729,11 +2834,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1023",
             "prereq": "Halfling Luck",
             "benefits": "Even other halflings consider you to be particularly lucky.",
-            "text": [
-                "Even other halflings consider you to be particularly lucky. You can use Halfling Luck once per hour, rather than once per day. If you have ",
-                ", you can still use Halfling Luck when you fail a Perception check or attack roll only once per day (though you can use it within the same hour that you used Halfling Luck), and if you have ",
-                ", you can still use Halfling Luck on an ally instead of yourself only once per day."
-            ]
+            "text": "Even other halflings consider you to be particularly lucky. You can use Halfling Luck once per hour, rather than once per day. If you have Guiding Luck, you can still use Halfling Luck when you fail a Perception check or attack roll only once per day (though you can use it within the same hour that you used Halfling Luck), and if you have Helpful Halfling, you can still use Halfling Luck on an ally instead of yourself only once per day."
+        },
+        {
+            "name": "Toppling Dance",
+            "level": "13",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1435",
+            "prereq": "Dance Underfoot",
+            "benefits": "While sharing a creature's space using Dance Underfoot, your weapons and unarmed attacks gain the trip trait, but only against the creature whose space you share.",
+            "text": "While sharing a creature's space using Dance Underfoot, your weapons and unarmed attacks gain the trip trait, but only against the creature whose space you share. You can be in the same space as a Large or larger prone creature, even if it's not your ally."
+        },
+        {
+            "name": "Shadow Self",
+            "level": "17",
+            "traits": [
+                "Halfling"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1436",
+            "prereq": "legendary Stealth",
+            "benefits": "With a powerful talent for misdirection, you slip from your adversaries' notice so thoroughly you appear to be somewhere else.",
+            "text": "With a powerful talent for misdirection, you slip from your adversaries' notice so thoroughly you appear to be somewhere else. You become invisible for 1 minute or until you take a hostile action, whichever comes first. Choose a location within 10 feet of you. Until your invisibility ends, you appear to be hidden in that location to anyone trying to find you. If the searcher gets clear evidence that you're not there, they no longer think you're hidden there, but they don't discover your actual location."
         }
     ],
     " halfOrcFeats": [
@@ -2746,31 +2869,30 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=66",
             "prereq": "spellcasting class feature",
             "benefits": "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style.",
-            "text": [
-                "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you\u2019re a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class\u2019s tradition.",
-                " If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one."
-            ]
+            "text": "Through study of multiple magical traditions, you've altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you're a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class's tradition. If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one.\r\n"
         },
         {
             "name": "Arcane Tattoos",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=938",
             "prereq": "\u2014",
             "benefits": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic.",
-            "text": [
-                "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (",
-                "), conjuration (",
-                "), enchantment (",
-                "), evocation (",
-                "), illusion (",
-                "), necromancy (",
-                "), or transmutation (",
-                "). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
-            ]
+            "text": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (shield), conjuration (tanglefoot), enchantment (daze), evocation (electric arc), illusion (ghost sound), necromancy (chill touch), or transmutation (sigil). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
+        },
+        {
+            "name": "Beast Trainer",
+            "level": "1",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1283",
+            "prereq": "\u2014",
+            "benefits": "You have an impressive innate ability to tame and command ferocious beasts.",
+            "text": "You have an impressive innate ability to tame and command ferocious beasts. You become trained in the Nature skill and gain the Train Animal skill feat."
         },
         {
             "name": "Cooperative Nature",
@@ -2781,42 +2903,32 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=67",
             "prereq": "\u2014",
             "benefits": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness.",
-            "text": [
-                "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid."
-            ]
+            "text": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid.\r\n"
         },
         {
-            "name": "Courteous Comback",
+            "name": "Courteous Comeback",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=939",
             "prereq": "\u2014",
             "benefits": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit.",
-            "text": [
-                "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
-            ]
+            "text": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
         },
         {
             "name": "Devil's Advocate",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=940",
             "prereq": "\u2014",
             "benefits": "You know more about the habits of devils than is entirely safe.",
-            "text": [
-                "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against ",
-                " and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a ",
-                " check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.",
-                " If you have the ",
-                " skill feat, you don\u2019t take the penalty to your immediate Diplomacy check if the target is a devil."
-            ]
+            "text": "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against devils and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result."
         },
         {
             "name": "Dragon Spit",
@@ -2827,13 +2939,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=941",
             "prereq": "Tian-Dan ethnicity",
             "benefits": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage.",
-            "text": [
-                "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: ",
-                ", ",
-                ", ",
-                ", or ",
-                ". You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
-            ]
+            "text": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: acid splash, electric arc, produce flame, or ray of frost. You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
         },
         {
             "name": "General Training",
@@ -2844,10 +2950,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=68",
             "prereq": "\u2014",
             "benefits": "Your adaptability manifests in your mastery of a range of useful abilities.",
-            "text": [
-                "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat\u2019s prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.",
-                " You can select this feat multiple times, choosing a different feat each time."
-            ]
+            "text": "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat's prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.\r\n"
         },
         {
             "name": "Gloomseer",
@@ -2858,10 +2961,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=942",
             "prereq": "Nidalese ethnicity",
             "benefits": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light.",
-            "text": [
-                "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain ",
-                "."
-            ]
+            "text": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain low-light vision."
         },
         {
             "name": "Haughty Obstinacy",
@@ -2872,40 +2972,43 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=69",
             "prereq": "\u2014",
             "benefits": "Your powerful ego makes it harder for others to order you around.",
-            "text": [
-                "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can\u2019t try to Coerce you again for 1 week)."
-            ]
+            "text": "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can't try to Coerce you again for 1 week).\r\n"
+        },
+        {
+            "name": "Iron Fists",
+            "level": "1",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1284",
+            "prereq": "\u2014",
+            "benefits": "Your fists have been forged by battle, your naturally tough skin and dense bone further hardened by conflict.",
+            "text": "Your fists have been forged by battle, your naturally tough skin and dense bone further hardened by conflict. Your fist unarmed attacks no longer have the nonlethal trait and gain the shove weapon trait."
         },
         {
             "name": "Keep Up Appearances",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=943",
             "prereq": "\u2014",
             "benefits": "Taldan pride means you never show weakness.",
-            "text": [
-                "Taldan pride means you never show weakness. Roll a ",
-                " check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a ",
-                " effect, it can\u2019t use its Feed on Fear ability on you."
-            ]
+            "text": "Taldan pride means you never show weakness. Roll a Deception check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a fear effect, it can\u2019t use its Feed on Fear ability on you."
         },
         {
             "name": "Know Oneself",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=944",
             "prereq": "\u2014",
             "benefits": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge.",
-            "text": [
-                "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
-            ]
+            "text": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
         },
         {
             "name": "Monstrous Peacemaker",
@@ -2916,9 +3019,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=82",
             "prereq": "\u2014",
             "benefits": "Your dual human and orc nature has given you a unique perspective.",
-            "text": [
-                "Your dual human and orc nature has given you a unique perspective, allowing you to bridge the gap between humans and the many intelligent creatures in the world that humans consider monsters. You gain a +1 circumstance bonus to Diplomacy checks against non-humanoid intelligent creatures and against humanoids that are marginalized in human society (at the GM\u2019s discretion, but typically at least including giants, goblins, kobolds, and orcs). You also gain this bonus on Perception checks to Sense the Motives of such creatures."
-            ]
+            "text": "Your dual human and orc nature has given you a unique perspective, allowing you to bridge the gap between humans and the many intelligent creatures in the world that humans consider monsters. You gain a +1 circumstance bonus to Diplomacy checks against non-humanoid intelligent creatures and against humanoids that are marginalized in human society (at the GM's discretion, but typically at least including giants, goblins, kobolds, and orcs). You also gain this bonus on Perception checks to Sense the Motives of such creatures.\r\n"
         },
         {
             "name": "Natural Ambition",
@@ -2929,9 +3030,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=70",
             "prereq": "\u2014",
             "benefits": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field.",
-            "text": [
-                "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
-            ]
+            "text": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
         },
         {
             "name": "Natural Skill",
@@ -2942,9 +3041,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=71",
             "prereq": "\u2014",
             "benefits": "Your ingenuity allows you to learn a wide variety of skills.",
-            "text": [
-                "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
-            ]
+            "text": "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
         },
         {
             "name": "Orc Ferocity",
@@ -2955,9 +3052,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=83",
             "prereq": "\u2014",
             "benefits": "Fierceness in battle runs through your blood, and you refuse to fall from your injuries.",
-            "text": [
-                "Fierceness in battle runs through your blood, and you refuse to fall from your injuries. You avoid being knocked out and remain at 1 Hit Point, and your wounded condition increases by 1."
-            ]
+            "text": "Fierceness in battle runs through your blood, and you refuse to fall from your injuries. You avoid being knocked out and remain at 1 Hit Point, and your wounded condition increases by 1.\r\n"
+        },
+        {
+            "name": "Orc Lore",
+            "level": "1",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1285",
+            "prereq": "\u2014",
+            "benefits": "The hold elders taught you your people's histories, told tales of great athletic feats, and shared with you the hardships your ancestors endured so that you can pass this wisdom down to future generations.",
+            "text": "The hold elders taught you your people's histories, told tales of great athletic feats, and shared with you the hardships your ancestors endured so that you can pass this wisdom down to future generations. You become trained in Athletics and Survival. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Orc Lore."
         },
         {
             "name": "Orc Sight",
@@ -2968,27 +3074,22 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=84",
             "prereq": "low-light vision",
             "benefits": "Your orc blood is strong enough to grant you the keen vision of your orc forebears.",
-            "text": [
-                "Your orc blood is strong enough to grant you the keen vision of your orc forebears. You gain darkvision, allowing you to see in darkness and dim light just as well as you can in bright light. However, in darkness, you see in black and white only.",
-                " You can take this feat only at 1st level, and you can\u2019t retrain out of this feat or into this feat."
-            ]
+            "text": "Your orc blood is strong enough to grant you the keen vision of your orc forebears. You gain darkvision, allowing you to see in darkness and dim light just as well as you can in bright light. However, in darkness, you see in black and white only.\r\n"
         },
         {
             "name": "Orc Superstition",
             "level": "1",
             "traits": [
                 "Orc",
-                " Concentrate"
+                "Concentrate"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=85",
             "prereq": "\u2014",
             "benefits": "You defend yourself against magic by relying on techniques derived from orc cultural superstitions.",
-            "text": [
-                "You defend yourself against magic by relying on techniques derived from orc cultural superstitions. You gain a +1 circumstance bonus to your saving throw against the triggering spell or magical effect."
-            ]
+            "text": "You defend yourself against magic by relying on techniques derived from orc cultural superstitions. You gain a +1 circumstance bonus to your saving throw against the triggering spell or magical effect."
         },
         {
-            "name": "Orc Weapon Famailiarity",
+            "name": "Orc Weapon Familiarity",
             "level": "1",
             "traits": [
                 "Orc"
@@ -2996,10 +3097,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=86",
             "prereq": "\u2014",
             "benefits": "In combat, you favor the brutal weapons that are traditional for your orc ancestors.",
-            "text": [
-                "In combat, you favor the brutal weapons that are traditional for your orc ancestors. You are trained with the falchion and greataxe. In addition, you gain access to all uncommon orc weapons.",
-                " For you, martial orc weapons are simple weapons, and advanced orc weapons are martial weapons."
-            ]
+            "text": "In combat, you favor the brutal weapons that are traditional for your orc ancestors. You are trained with the falchion and greataxe. In addition, you gain access to all uncommon orc weapons. For the purpose of determining your proficiency, martial orc weapons are simple weapons and advanced orc weapons are martial weapons."
         },
         {
             "name": "Overlooked Mastermind",
@@ -3010,70 +3108,55 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=962",
             "prereq": "\u2014",
             "benefits": "Many consider half-orcs little more than dumb brutes.",
-            "text": [
-                "Many consider half-orcs little more than dumb brutes. This is offensive to you, but it can occasionally be useful. You are trained in ",
-                " (or another skill of your choice if you were already trained in Deception), and you gain a +2 circumstance bonus to Deception checks to Lie when specifically claiming ignorance and to Deception DCs against ",
-                " checks to uncover such lies."
-            ]
+            "text": "Many consider half-orcs little more than dumb brutes. This is offensive to you, but it can occasionally be useful. You are trained in Deception (or another skill of your choice if you were already trained in Deception), and you gain a +2 circumstance bonus to Deception checks to Lie when specifically claiming ignorance and to Deception DCs against Sense Motive checks to uncover such lies."
         },
         {
             "name": "Quah Bond",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=945",
             "prereq": "\u2014",
             "benefits": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance.",
-            "text": [
-                "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the ",
-                " skill feat in that skill, as the spirits\u2019 help guides your actions. "
-            ]
+            "text": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the Assurance skill feat in that skill, as the spirits\u2019 help guides your actions. Lyrune-Quah Religion Shadde-Quah Athletics Shriikirri-Quah Nature Shundar-Quah Diplomacy Sklar-Quah Intimidation Skoan-Quah Medicine Tamiir-Quah Acrobatics"
         },
         {
             "name": "Saoc Astrology",
             "level": "1",
             "traits": [
                 "Human",
-                " Concentrate",
-                " Uncommon"
+                "Concentrate",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=946",
             "prereq": "\u2014",
             "benefits": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy.",
-            "text": [
-                "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
-            ]
+            "text": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
         },
         {
             "name": "Tupilaq Carver",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=947",
             "prereq": "You have a spellcasting class feature with the divine or primal tradition",
             "benefits": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance.",
-            "text": [
-                "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the ",
-                " spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
-            ]
+            "text": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the summon construct spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
         },
         {
             "name": "Tusks",
             "level": "1",
             "traits": [
-                "Half-Orc"
+                "Orc"
             ],
-            "link": "https://2e.aonprd.com/Feats.aspx?ID=963",
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1286",
             "prereq": "\u2014",
-            "benefits": "Most half-orcs have visible tusks, but yours are particularly large and sharp, capable of gouging deep wounds.",
-            "text": [
-                "Most half-orcs have visible tusks, but yours are particularly large and sharp, capable of gouging deep wounds. You gain a jaws unarmed attack that deals 1d6 piercing damage.",
-                " You can take this feat only at 1st level, and you can\u2019t retrain out of this feat or into this feat."
-            ]
+            "benefits": "You have particularly long, jagged tusks perfect for tearing meat from bone.",
+            "text": "You have particularly long, jagged tusks perfect for tearing meat from bone. You gain a tusks unarmed attack that deals 1d6 piercing damage. Your tusks are in the brawling group and have the finesse and unarmed traits."
         },
         {
             "name": "Unconventional Weaponry",
@@ -3084,41 +3167,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=72",
             "prereq": "\u2014",
             "benefits": "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture.",
-            "text": [
-                "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon.",
-                " If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon."
-            ]
+            "text": "You've familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon. If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon.\r\n"
         },
         {
             "name": "Viking Shieldbearer",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=948",
             "prereq": "\u2014",
             "benefits": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself.",
-            "text": [
-                "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the ",
-                " reaction and are trained in your choice of the battle axe or longsword."
-            ]
+            "text": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the Shield Block reaction and are trained in your choice of the battle axe or longsword."
         },
         {
             "name": "Witch Warden",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=949",
             "prereq": "\u2014",
             "benefits": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant.",
-            "text": [
-                "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against ",
-                ", and to saving throws against spells cast by a witch or ",
-                ". If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
-            ]
+            "text": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against curses, and to saving throws against spells cast by a witch or hag. If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
         },
         {
             "name": "Adaptive Adept",
@@ -3129,10 +3202,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=73",
             "prereq": "Adapted Cantrip, can cast 3rd-level spells",
             "benefits": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition.",
-            "text": [
-                "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from ",
-                ". You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
-            ]
+            "text": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from Adapted Cantrip. You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
+        },
+        {
+            "name": "Athletic Might",
+            "level": "5",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1287",
+            "prereq": "\u2014",
+            "benefits": "Surviving in hostile terrain has given you a great talent for mobility.",
+            "text": "Surviving in hostile terrain has given you a great talent for mobility. Whenever you roll a success on an Athletics check to Climb or Swim, you get a critical success instead."
+        },
+        {
+            "name": "Bloody Blows",
+            "level": "5",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1288",
+            "prereq": "\u2014",
+            "benefits": "Your lethal unarmed attacks leave bloody gouges or cause severe internal bleeding.",
+            "text": "Your lethal unarmed attacks leave bloody gouges or cause severe internal bleeding. When you critically hit with a Strike using an unarmed attack that isn't nonlethal, the target takes 1d4 persistent bleed damage. This can be because you're taking the penalty to use a fist for a lethal attack or because you have an unarmed attack without the nonlethal trait due to Iron Fists, Tusks, or a similar ability."
         },
         {
             "name": "Clever Improviser",
@@ -3143,10 +3235,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=74",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned how to handle situations when you\u2019re out of your depth.",
-            "text": [
-                "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the ",
-                " general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
-            ]
+            "text": "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the Untrained Improvisation general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
         },
         {
             "name": "Darkseer",
@@ -3157,10 +3246,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=950",
             "prereq": "Gloomseer",
             "benefits": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness.",
-            "text": [
-                " smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain ",
-                "."
-            ]
+            "text": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain darkvision."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
+        },
+        {
+            "name": "Hold Mark",
+            "level": "5",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1289",
+            "prereq": "\u2014",
+            "benefits": "You bear scars or tattoos enhanced by the mark of your community's prowess. ",
+            "text": "You bear scars or tattoos enhanced by the mark of your community's prowess. When you select this feat, choose one of the options on the following page. When you critically hit using a weapon of the listed group, you apply the weapon's critical specialization effect. You gain a large brand or tattoo in the shape of the chosen emblem or a similar image (for example, the axe could be a bear or other symbol of ferocious strength, while the shield might be a turtle or another symbol associated with a strong defense) and gain the listed benefit. Axe axe or pickShield hammer or shieldTorch bomb or knife "
         },
         {
             "name": "Orc Weapon Carnage",
@@ -3171,9 +3279,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=87",
             "prereq": "Orc Weapon Familiarity",
             "benefits": "You are brutally efficient with the weapons of your orc ancestors.",
-            "text": [
-                "You are brutally efficient with the weapons of your orc ancestors. Whenever you critically hit using a falchion, a greataxe, or an orc weapon, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You are brutally efficient with the weapons of your orc ancestors. Whenever you critically hit using a falchion, a greataxe, or an orc weapon, you apply the weapon's critical specialization effect.\r\n"
         },
         {
             "name": "Ornate Tattoo",
@@ -3184,10 +3290,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=951",
             "prereq": "Arcane Tattoos",
             "benefits": "You expand your tattoos to encompass greater magic.",
-            "text": [
-                "You expand your tattoos to encompass greater magic. Choose a 1st-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "You expand your tattoos to encompass greater magic. Choose a 1st-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Sense Allies",
+            "level": "5",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1437",
+            "prereq": "\u2014",
+            "benefits": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others.",
+            "text": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others. Willing allies that you are aware of within 60 feet that would otherwise be undetected by you are instead hidden from you. The flat check for you to target willing allies within 60 feet that are hidden from you is 5 instead of 11."
         },
         {
             "name": "Victorious Vigor",
@@ -3198,9 +3312,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=88",
             "prereq": "\u2014",
             "benefits": "Your victories in battle fill you with pride and imbue you with the energy to fight a bit longer despite your wounds.",
-            "text": [
-                "Your victories in battle fill you with pride and imbue you with the energy to fight a bit longer despite your wounds. You gain temporary Hit Points equal to your Constitution modifier until the end of your next turn."
-            ]
+            "text": "Your victories in battle fill you with pride and imbue you with the energy to fight a bit longer despite your wounds. You gain temporary Hit Points equal to your Constitution modifier until the end of your next turn."
         },
         {
             "name": "Wavetouched Paragon",
@@ -3211,11 +3323,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=952",
             "prereq": "Bonuwat ethnicity",
             "benefits": "You have been blessed by the sea, granting you the ability to swim like a fish.",
-            "text": [
-                "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed.",
-                " If you have the ",
-                " background, you can take this feat at 1st level instead of 5th."
-            ]
+            "text": "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed."
         },
         {
             "name": "Cooperative Soul",
@@ -3226,9 +3334,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=75",
             "prereq": "Cooperative Nature",
             "benefits": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them.",
-            "text": [
-                "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success."
-            ]
+            "text": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success.\r\n"
+        },
+        {
+            "name": "Death's Drums",
+            "level": "9",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1290",
+            "prereq": "\u2014",
+            "benefits": "Your life has been spent challenging death itself, and proximity to that implacable foe only makes your heart beat harder.",
+            "text": "Your life has been spent challenging death itself, and proximity to that implacable foe only makes your heart beat harder. When you are taking persistent damage or your wounded value is 1 or greater, you gain a +2 circumstance bonus to Fortitude saving throws."
         },
         {
             "name": "Dragon Prince",
@@ -3239,10 +3356,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=953",
             "prereq": "Dragon Spit",
             "benefits": "The blood of the Dragon Kings runs strong in your veins.",
-            "text": [
-                "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the ",
-                " sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
-            ]
+            "text": "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the dragon breath sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
+        },
+        {
+            "name": "Group Aid",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1438",
+            "prereq": "\u2014",
+            "benefits": "Your upbringing emphasized teamwork and helping your allies comes naturally to you.",
+            "text": "Your upbringing emphasized teamwork and helping your allies comes naturally to you. After you Aid an ally at a skill check that doesn't have the attack trait, you can also Aid any other ally who attempts the same skill check for the same purpose that round. You do so as a free action rather than a reaction. The preparation you did to help must still apply to the other allies, and you can Aid each ally only once. For example, if you helped lift up an ally to Aid them on an Athletics check to scale a wall, you could keep the same posture to give a boost to other allies attempting to scale the wall in the same round."
+        },
+        {
+            "name": "Hardy Traveler",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1439",
+            "prereq": "\u2014",
+            "benefits": "There's no journey too far or burden too heavy when your friends are at your side.",
+            "text": "There's no journey too far or burden too heavy when your friends are at your side. Increase your maximum and encumbered Bulk limits by 1. In addition, you gain a +10-foot circumstance bonus to your Speed during overland travel."
         },
         {
             "name": "Heir of the Saoc",
@@ -3253,9 +3389,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=954",
             "prereq": "Saoc Astrology",
             "benefits": "In the past, you would have been a proud initiate of the Saoc Brethren.",
-            "text": [
-                "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
-            ]
+            "text": "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
         },
         {
             "name": "Incredible Improvisation",
@@ -3266,9 +3400,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=76",
             "prereq": "Clever Improviser",
             "benefits": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience.",
-            "text": [
-                "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
-            ]
+            "text": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
         },
         {
             "name": "Multitalented",
@@ -3279,10 +3411,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=77",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned to split your focus between multiple classes with ease.",
-            "text": [
-                "You\u2019ve learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat (for more about multiclass archetypes, see page 219), even if you normally couldn\u2019t take another dedication feat until you take more feats from your current archetype.",
-                " If you\u2019re a half-elf, you don\u2019t need to meet the feat\u2019s ability score prerequisites."
-            ]
+            "text": "You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype. If you're a half-elf, you don't need to meet the feat's ability score prerequisites.\r\n"
         },
         {
             "name": "Pervasive Superstition",
@@ -3293,9 +3422,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=89",
             "prereq": "Orc Superstition",
             "benefits": "You steep yourself in superstition and practice ancient orc mental exercises for shrugging off the effects of magic.",
-            "text": [
-                "You steep yourself in superstition and practice ancient orc mental exercises for shrugging off the effects of magic. You gain a +1 circumstance bonus to saving throws against spells and magical effects at all times."
-            ]
+            "text": "You steep yourself in superstition and practice ancient orc mental exercises for shrugging off the effects of magic. You gain a +1 circumstance bonus to saving throws against spells and magical effects at all times."
         },
         {
             "name": "Shory Aeromancer",
@@ -3306,13 +3433,21 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=955",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity",
             "benefits": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you.",
-            "text": [
-                "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level ",
-                " on yourself as an innate arcane spell once per day."
-            ]
+            "text": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level fly on yourself as an innate arcane spell once per day."
         },
         {
-            "name": "Virtue-Forged Tattooed",
+            "name": "Undying Ferocity",
+            "level": "9",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1291",
+            "prereq": "Orc Ferocity ",
+            "benefits": "You resist death's clutches with supernatural vigor.",
+            "text": "You resist death's clutches with supernatural vigor. When you use Orc Ferocity, you gain temporary Hit Points equal to your level."
+        },
+        {
+            "name": "Virtue-Forged Tattoos",
             "level": "9",
             "traits": [
                 "Human"
@@ -3320,10 +3455,40 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=956",
             "prereq": "Ornate Tattoo",
             "benefits": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin.",
-            "text": [
-                "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Advanced General Training",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1440",
+            "prereq": "\u2014",
+            "benefits": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities.",
+            "text": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities. You gain a general feat of 7th level or lower. You must meet the feat's prerequisites."
+        },
+        {
+            "name": "Bounce Back",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1441",
+            "prereq": "\u2014",
+            "benefits": "You recover from near-death experiences with astounding resilience.",
+            "text": "You recover from near-death experiences with astounding resilience. Don't increase the value of your wounded condition due to losing the dying condition."
+        },
+        {
+            "name": "Ferocious Beasts",
+            "level": "13",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1292",
+            "prereq": "Beast Trainer or animal companion, Orc Ferocity",
+            "benefits": "Since ancient times, the mightiest orc beast tamers would draw out the true fighting spirit of their companion beasts by feeding the creatures a draft incorporating the orc's own blood.",
+            "text": "Since ancient times, the mightiest orc beast tamers would draw out the true fighting spirit of their companion beasts by feeding the creatures a draft incorporating the orc's own blood. Animal companions or bonded animals you have gain the Orc Ferocity feat, and they gain a reaction they can use only for Orc Ferocity. If you have the Undying Ferocity ancestry feat, all animal companions or bonded animals you have also gain the benefits of that feat when using the Orc Ferocity reaction."
         },
         {
             "name": "Incredible Ferocity",
@@ -3334,10 +3499,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=90",
             "prereq": "Orc Ferocity",
             "benefits": "Given time to collect yourself after a near-death scrape, you can rebuild your ferocity and withstand additional finishing blows.",
-            "text": [
-                "Given time to collect yourself after a near-death scrape, you can rebuild your ferocity and withstand additional finishing blows. You can use ",
-                " with a frequency of once per hour, rather than once per day."
-            ]
+            "text": "Given time to collect yourself after a near-death scrape, you can rebuild your ferocity and withstand additional finishing blows. You can use Orc Ferocity with a frequency of once per hour, rather than once per day."
         },
         {
             "name": "Irriseni Ice-Witch",
@@ -3348,10 +3510,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=957",
             "prereq": "Jadwiga ethnicity, wintertouched human heritage",
             "benefits": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself.",
-            "text": [
-                "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level ",
-                " as an innate arcane spell once per day."
-            ]
+            "text": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level wall of ice as an innate arcane spell once per day."
         },
         {
             "name": "Orc Weapon Expertise",
@@ -3362,9 +3521,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=91",
             "prereq": "Orc Weapon Familiarity",
             "benefits": "Your orc affinity blends with your class training, granting you great skill with orc weapons.",
-            "text": [
-                "Your orc affinity blends with your class training, granting you great skill with orc weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the falchion, the greataxe, and all orc weapons in which you are trained."
-            ]
+            "text": "Your orc affinity blends with your class training, granting you great skill with orc weapons. Whenever you gain a class feature that grants you expert or greater proficiency in a given weapon or weapons, you also gain that proficiency in the falchion, the greataxe, and all orc weapons in which you are trained."
         },
         {
             "name": "Shadow Pact",
@@ -3375,11 +3532,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=958",
             "prereq": "Nidalese ethnicity",
             "benefits": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon.",
-            "text": [
-                "Thousands of years ago, your ancestors made a pact with ",
-                ". He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level ",
-                " as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
-            ]
+            "text": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon. He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level creation as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
         },
         {
             "name": "Shory Aerialist",
@@ -3390,10 +3543,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=959",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity; Shory Aeromancer or ability to cast fly",
             "benefits": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air.",
-            "text": [
-                "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to ",
-                " checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
-            ]
+            "text": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to Acrobatics checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
+        },
+        {
+            "name": "Spell Devourer",
+            "level": "13",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1293",
+            "prereq": "Pervasive Superstition ",
+            "benefits": "You don't just resist magic; you devour it.",
+            "text": "You don't just resist magic; you devour it. Whenever you succeed at a saving throw against a spell or magical effect, you gain temporary Hit Points equal to double the spell's level, or equal to the level if the magical effect isn't a spell. These temporary Hit Points last until the end of your next turn."
+        },
+        {
+            "name": "Stubborn Persistence",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1442",
+            "prereq": "\u2014",
+            "benefits": "Humans are renowned for their ability to persist through the most grueling of trials.",
+            "text": "Humans are renowned for their ability to persist through the most grueling of trials. When you would become fatigued, attempt a DC 17 flat check. On a success, you aren't fatigued. If the fatigued condition has an underlying cause that you don't address, such as lack of rest, you must attempt the check again at an interval determined by the GM until you fail the flat check or address the underlying cause."
         },
         {
             "name": "Unconventional Expertise",
@@ -3404,10 +3576,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=78",
             "prereq": "Unconventional Weaponry, trained in the weapon you chose for Unconventional Weaponry",
             "benefits": "You\u2019ve continued to advance your powers using your unconventional weapon.",
-            "text": [
-                "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for ",
-                "."
-            ]
+            "text": "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for Unconventional Weaponry."
+        },
+        {
+            "name": "Heroic Presence",
+            "level": "17",
+            "traits": [
+                "Human",
+                "Emotion",
+                "Mental"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1443",
+            "prereq": "\u2014",
+            "benefits": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve.",
+            "text": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve. You grant up to 10 willing creatures within 30 feet the effects of a 6th-level zealous conviction, though the effect automatically ends on a target if you give that target a command they would normally find repugnant. This action has the auditory trait or visual trait, depending on how you inspire your allies."
+        },
+        {
+            "name": "Rampaging Ferocity",
+            "level": "17",
+            "traits": [
+                "Orc"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1294",
+            "prereq": "Orc Ferocity",
+            "benefits": "You lash out viciously even as you fend off death.",
+            "text": "You lash out viciously even as you fend off death. Make a single melee Strike. If this Strike brings a foe to 0 Hit Points, this activation of Orc Ferocity doesn't count against its frequency."
         }
     ],
     " humanFeats": [
@@ -3420,31 +3613,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=66",
             "prereq": "spellcasting class feature",
             "benefits": "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style.",
-            "text": [
-                "Through study of multiple magical traditions, you\u2019ve altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you\u2019re a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class\u2019s tradition.",
-                " If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one."
-            ]
+            "text": "Through study of multiple magical traditions, you've altered a spell to suit your spellcasting style. Choose one cantrip from a magical tradition other than your own. If you have a spell repertoire or a spellbook, replace one of the cantrips you know or have in your spellbook with the chosen spell. If you prepare spells without a spellbook (if you're a cleric or druid, for example), one of your cantrips must always be the chosen spell, and you prepare the rest normally. You can cast this cantrip as a spell of your class's tradition. If you swap or retrain this cantrip later, you can choose its replacement from the same alternate tradition or a different one.\r\n"
         },
         {
             "name": "Arcane Tattoos",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=938",
             "prereq": "\u2014",
             "benefits": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic.",
-            "text": [
-                "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (",
-                "), conjuration (",
-                "), enchantment (",
-                "), evocation (",
-                "), illusion (",
-                "), necromancy (",
-                "), or transmutation (",
-                "). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
-            ]
+            "text": "You have tattoos on your body corresponding to one of the ancient Thassilonian schools of magic. Choose one of the following schools of magic: abjuration (shield), conjuration (tanglefoot), enchantment (daze), evocation (electric arc), illusion (ghost sound), necromancy (chill touch), or transmutation (sigil). You can cast the associated cantrip (listed in parentheses) as an innate arcane spell at will.\r"
         },
         {
             "name": "Cooperative Nature",
@@ -3455,42 +3636,32 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=67",
             "prereq": "\u2014",
             "benefits": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness.",
-            "text": [
-                "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid."
-            ]
+            "text": "The short human life span lends perspective and has taught you from a young age to set aside differences and work with others to achieve greatness. You gain a +4 circumstance bonus on checks to Aid.\r\n"
         },
         {
-            "name": "Courteous Comback",
+            "name": "Courteous Comeback",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=939",
             "prereq": "\u2014",
             "benefits": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit.",
-            "text": [
-                "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
-            ]
+            "text": "You grew up in the proud Padishah Empire, where even insults have a certain poetic wit. Reroll the triggering Diplomacy check, using the second result."
         },
         {
             "name": "Devil's Advocate",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=940",
             "prereq": "\u2014",
             "benefits": "You know more about the habits of devils than is entirely safe.",
-            "text": [
-                "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against ",
-                " and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a ",
-                " check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result.",
-                " If you have the ",
-                " skill feat, you don\u2019t take the penalty to your immediate Diplomacy check if the target is a devil."
-            ]
+            "text": "You know more about the habits of devils than is entirely safe. You gain a +2 circumstance bonus to Perception checks against devils and saving throws against their abilities. In addition, whenever you meet a devil in a social situation, you can immediately attempt a Diplomacy check to Make an Impression on that creature rather than needing to converse for 1 minute. You take a \u20135 penalty to the check. If you fail, you can engage in 1 minute of conversation and attempt a new check at the end of that time rather than accepting the failure or critical failure result."
         },
         {
             "name": "Dragon Spit",
@@ -3501,13 +3672,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=941",
             "prereq": "Tian-Dan ethnicity",
             "benefits": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage.",
-            "text": [
-                "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: ",
-                ", ",
-                ", ",
-                ", or ",
-                ". You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
-            ]
+            "text": "Many Tian-Dan claim to have dragon blood in their veins, and in your case, this is true\u2014you can spit energy, and you might have an especially visible sign of your draconic heritage. Choose one of the following cantrips: acid splash, electric arc, produce flame, or ray of frost. You can cast this spell as an innate arcane spell at will, and when you cast it, the spell\u2019s energy emerges from your mouth."
         },
         {
             "name": "General Training",
@@ -3518,10 +3683,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=68",
             "prereq": "\u2014",
             "benefits": "Your adaptability manifests in your mastery of a range of useful abilities.",
-            "text": [
-                "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat\u2019s prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.",
-                " You can select this feat multiple times, choosing a different feat each time."
-            ]
+            "text": "Your adaptability manifests in your mastery of a range of useful abilities. You gain a 1st-level general feat. You must meet the feat's prerequisites, but if you select this feat during character creation, you can select the feat later in the process in order to determine which prerequisites you meet.\r\n"
         },
         {
             "name": "Gloomseer",
@@ -3532,10 +3694,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=942",
             "prereq": "Nidalese ethnicity",
             "benefits": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light.",
-            "text": [
-                "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain ",
-                "."
-            ]
+            "text": "Gloom holds few terrors for you, and the pall of darkness over Nidal has made you comfortable in dim light. You gain low-light vision."
         },
         {
             "name": "Haughty Obstinacy",
@@ -3546,40 +3705,32 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=69",
             "prereq": "\u2014",
             "benefits": "Your powerful ego makes it harder for others to order you around.",
-            "text": [
-                "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can\u2019t try to Coerce you again for 1 week)."
-            ]
+            "text": "Your powerful ego makes it harder for others to order you around. If you roll a success on a saving throw against a mental effect that attempts to directly control your actions, you critically succeed instead. If a creature rolls a failure on a check to Coerce you using Intimidation, it gets a critical failure instead (so it can't try to Coerce you again for 1 week).\r\n"
         },
         {
             "name": "Keep Up Appearances",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=943",
             "prereq": "\u2014",
             "benefits": "Taldan pride means you never show weakness.",
-            "text": [
-                "Taldan pride means you never show weakness. Roll a ",
-                " check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a ",
-                " effect, it can\u2019t use its Feed on Fear ability on you."
-            ]
+            "text": "Taldan pride means you never show weakness. Roll a Deception check and compare the result to any observing creatures\u2019 Perception DCs. On a success, that creature believes you were unaffected by the emotion effect. A creature tricked in this manner can\u2019t benefit from the emotion effect and can\u2019t use abilities that require you to be under this emotion effect; for example, if you successfully use this ability to trick a will-o\u2019-wisp into believing you aren\u2019t under a fear effect, it can\u2019t use its Feed on Fear ability on you."
         },
         {
             "name": "Know Oneself",
             "level": "1",
             "traits": [
                 "Human",
-                " Fortune",
-                " Uncommon"
+                "Fortune",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=944",
             "prereq": "\u2014",
             "benefits": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge.",
-            "text": [
-                "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
-            ]
+            "text": "You center yourself and call to mind the Vudrani monastic ideals of mindfulness and self-knowledge. You fail the save against the emotion effect instead of critically failing."
         },
         {
             "name": "Natural Ambition",
@@ -3590,9 +3741,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=70",
             "prereq": "\u2014",
             "benefits": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field.",
-            "text": [
-                "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
-            ]
+            "text": "You were raised to be ambitious and always reach for the stars, leading you to progress quickly in your chosen field. You gain a 1st-level class feat for your class. You must meet the prerequisites, but you can select the feat later in the character creation process in order to determine which prerequisites you meet."
         },
         {
             "name": "Natural Skill",
@@ -3603,54 +3752,44 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=71",
             "prereq": "\u2014",
             "benefits": "Your ingenuity allows you to learn a wide variety of skills.",
-            "text": [
-                "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
-            ]
+            "text": "Your ingenuity allows you to learn a wide variety of skills. You gain the trained proficiency rank in two skills of your choice."
         },
         {
             "name": "Quah Bond",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=945",
             "prereq": "\u2014",
             "benefits": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance.",
-            "text": [
-                "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the ",
-                " skill feat in that skill, as the spirits\u2019 help guides your actions. "
-            ]
+            "text": "You grew up among the Shoanti tribes, with the spirits watching over you, and they offer you guidance. You gain the trained proficiency rank in the skill listed for your quah (or another skill of your choice, if you\u2019re already trained in that skill). You gain the Assurance skill feat in that skill, as the spirits\u2019 help guides your actions. Lyrune-Quah Religion Shadde-Quah Athletics Shriikirri-Quah Nature Shundar-Quah Diplomacy Sklar-Quah Intimidation Skoan-Quah Medicine Tamiir-Quah Acrobatics"
         },
         {
             "name": "Saoc Astrology",
             "level": "1",
             "traits": [
                 "Human",
-                " Concentrate",
-                " Uncommon"
+                "Concentrate",
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=946",
             "prereq": "\u2014",
             "benefits": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy.",
-            "text": [
-                "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
-            ]
+            "text": "The ancient Saoc Brethren were the masters of astrology, and while your knowledge may be but a pale shadow of their wisdom, it still comes in handy. You recall the stars\u2019 predictions about your current situation. If your next action requires you to attempt one or more skill checks, roll 1d8. On a result of 6, 7, or 8, you gain a +2 circumstance bonus to the first such skill check you attempt. On a 3, 4, or 5, you gain a +1 circumstance bonus. On a 2, you gain nothing. On a 1, you take a \u20131 circumstance penalty to the skill check."
         },
         {
             "name": "Tupilaq Carver",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=947",
             "prereq": "You have a spellcasting class feature with the divine or primal tradition",
             "benefits": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance.",
-            "text": [
-                "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the ",
-                " spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
-            ]
+            "text": "You know the truth behind old stories that tell of sending a fetish of bone and sinew to seek vengeance. These old magics allow you to conjure constructs with ease. Add the summon construct spell to your spell list. The constructs you summon have a distinct ivory scrimshaw appearance, and if you include a drop of blood, lock of hair, or other portion of a creature\u2019s body as part of the spell\u2019s material component, the summoned construct gains a +4 status bonus to Perception checks to sense or locate that creature."
         },
         {
             "name": "Unconventional Weaponry",
@@ -3661,41 +3800,31 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=72",
             "prereq": "\u2014",
             "benefits": "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture.",
-            "text": [
-                "You\u2019ve familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon.",
-                " If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon."
-            ]
+            "text": "You've familiarized yourself with a particular weapon, potentially from another ancestry or culture. Choose an uncommon simple or martial weapon with a trait corresponding to an ancestry (such as dwarf, goblin, or orc) or that is common in another culture. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a simple weapon. If you are trained in all martial weapons, you can choose an uncommon advanced weapon with such a trait. You gain access to that weapon, and for the purpose of determining your proficiency, that weapon is a martial weapon.\r\n"
         },
         {
             "name": "Viking Shieldbearer",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=948",
             "prereq": "\u2014",
             "benefits": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself.",
-            "text": [
-                "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the ",
-                " reaction and are trained in your choice of the battle axe or longsword."
-            ]
+            "text": "You trained with shields and weapons as soon as you were old enough to hold them, eager to win honor and glory for yourself. You gain the Shield Block reaction and are trained in your choice of the battle axe or longsword."
         },
         {
             "name": "Witch Warden",
             "level": "1",
             "traits": [
                 "Human",
-                " Uncommon"
+                "Uncommon"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=949",
             "prereq": "\u2014",
             "benefits": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant.",
-            "text": [
-                "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against ",
-                ", and to saving throws against spells cast by a witch or ",
-                ". If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
-            ]
+            "text": "You and your family have fought long and hard against witches, particularly the winter witches of Irrisen, and you\u2019ve learned to be wary of their curses and the otherworldly powers their patrons grant. You gain a +1 circumstance bonus to saving throws against curses, and to saving throws against spells cast by a witch or hag. If you roll a success on a saving throw against a curse or a spell cast by a witch or hag, you get a critical success instead."
         },
         {
             "name": "Adaptive Adept",
@@ -3706,10 +3835,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=73",
             "prereq": "Adapted Cantrip, can cast 3rd-level spells",
             "benefits": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition.",
-            "text": [
-                "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from ",
-                ". You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
-            ]
+            "text": "You\u2019ve continued adapting your magic to blend your class\u2019s tradition with your adapted tradition. Choose a cantrip or 1st-level spell from the same magical tradition as your cantrip from Adapted Cantrip. You gain that spell, adding it to your spell repertoire, spellbook, or prepared spells just like the cantrip from Adapted Cantrip. You can cast this spell as a spell of your class\u2019s magical tradition. If you choose a 1st-level spell, you don\u2019t gain access to the heightened versions of that spell, meaning you can\u2019t prepare them if you prepare spells and you can\u2019t learn them or select the spell as a signature spell if you have a spell repertoire."
         },
         {
             "name": "Clever Improviser",
@@ -3720,10 +3846,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=74",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned how to handle situations when you\u2019re out of your depth.",
-            "text": [
-                "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the ",
-                " general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
-            ]
+            "text": "You\u2019ve learned how to handle situations when you\u2019re out of your depth. You gain the Untrained Improvisation general feat. In addition, you can attempt skill actions that normally require you to be trained, even if you are untrained."
         },
         {
             "name": "Darkseer",
@@ -3734,10 +3857,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=950",
             "prereq": "Gloomseer",
             "benefits": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness.",
-            "text": [
-                " smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain ",
-                "."
-            ]
+            "text": "Zon-Kuthon smiles upon you\u2014even if you curse his name\u2014granting you pitch-black eyes that allow you to see in shadows and darkness. You gain darkvision."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Human",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Ornate Tattoo",
@@ -3748,10 +3880,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=951",
             "prereq": "Arcane Tattoos",
             "benefits": "You expand your tattoos to encompass greater magic.",
-            "text": [
-                "You expand your tattoos to encompass greater magic. Choose a 1st-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "You expand your tattoos to encompass greater magic. Choose a 1st-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Sense Allies",
+            "level": "5",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1437",
+            "prereq": "\u2014",
+            "benefits": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others.",
+            "text": "Like many humans raised in a close-knit community, you have always been strongly attuned to the presence of others. Willing allies that you are aware of within 60 feet that would otherwise be undetected by you are instead hidden from you. The flat check for you to target willing allies within 60 feet that are hidden from you is 5 instead of 11."
         },
         {
             "name": "Wavetouched Paragon",
@@ -3762,11 +3902,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=952",
             "prereq": "Bonuwat ethnicity",
             "benefits": "You have been blessed by the sea, granting you the ability to swim like a fish.",
-            "text": [
-                "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed.",
-                " If you have the ",
-                " background, you can take this feat at 1st level instead of 5th."
-            ]
+            "text": "You have been blessed by the sea, granting you the ability to swim like a fish. You gain a 15-foot swim Speed."
         },
         {
             "name": "Cooperative Soul",
@@ -3777,9 +3913,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=75",
             "prereq": "Cooperative Nature",
             "benefits": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them.",
-            "text": [
-                "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success."
-            ]
+            "text": "You have developed a soul-deep bond with your comrades and maintain an even greater degree of cooperation with them. If you are at least an expert in the skill you are Aiding, you get a success on any outcome rolled to Aid other than a critical success.\r\n"
         },
         {
             "name": "Dragon Prince",
@@ -3790,10 +3924,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=953",
             "prereq": "Dragon Spit",
             "benefits": "The blood of the Dragon Kings runs strong in your veins.",
-            "text": [
-                "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the ",
-                " sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
-            ]
+            "text": "The blood of the Dragon Kings runs strong in your veins. Your draconic heritage is clearly visible, with hair that is almost entirely crimson, azure, or the like, and that shines like a dragon\u2019s scales. You can cast the dragon breath sorcerer bloodline spell as an innate arcane spell once per day, but you can use only the dragon breath that is associated with your heritage and that matches the energy type of your Dragon Spit feat. At 12th level and every 3 levels thereafter, the spell is heightened by an additional spell level."
+        },
+        {
+            "name": "Group Aid",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1438",
+            "prereq": "\u2014",
+            "benefits": "Your upbringing emphasized teamwork and helping your allies comes naturally to you.",
+            "text": "Your upbringing emphasized teamwork and helping your allies comes naturally to you. After you Aid an ally at a skill check that doesn't have the attack trait, you can also Aid any other ally who attempts the same skill check for the same purpose that round. You do so as a free action rather than a reaction. The preparation you did to help must still apply to the other allies, and you can Aid each ally only once. For example, if you helped lift up an ally to Aid them on an Athletics check to scale a wall, you could keep the same posture to give a boost to other allies attempting to scale the wall in the same round."
+        },
+        {
+            "name": "Hardy Traveler",
+            "level": "9",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1439",
+            "prereq": "\u2014",
+            "benefits": "There's no journey too far or burden too heavy when your friends are at your side.",
+            "text": "There's no journey too far or burden too heavy when your friends are at your side. Increase your maximum and encumbered Bulk limits by 1. In addition, you gain a +10-foot circumstance bonus to your Speed during overland travel."
         },
         {
             "name": "Heir of the Saoc",
@@ -3804,9 +3957,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=954",
             "prereq": "Saoc Astrology",
             "benefits": "In the past, you would have been a proud initiate of the Saoc Brethren.",
-            "text": [
-                "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
-            ]
+            "text": "In the past, you would have been a proud initiate of the Saoc Brethren. Today, you carry on their legacy. When you use Saoc Astrology, roll 1d4 instead; on a 1, you take a \u20131 penalty to the skill check. On any other result, you gain a circumstance bonus of that value (for instance, a +3 circumstance bonus on a 3)."
         },
         {
             "name": "Incredible Improvisation",
@@ -3817,9 +3968,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=76",
             "prereq": "Clever Improviser",
             "benefits": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience.",
-            "text": [
-                "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
-            ]
+            "text": "A stroke of brilliance gives you a major advantage with a skill despite your inexperience. Gain a +4 circumstance bonus to the triggering skill check."
         },
         {
             "name": "Multitalented",
@@ -3830,10 +3979,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=77",
             "prereq": "\u2014",
             "benefits": "You\u2019ve learned to split your focus between multiple classes with ease.",
-            "text": [
-                "You\u2019ve learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat (for more about multiclass archetypes, see page 219), even if you normally couldn\u2019t take another dedication feat until you take more feats from your current archetype.",
-                " If you\u2019re a half-elf, you don\u2019t need to meet the feat\u2019s ability score prerequisites."
-            ]
+            "text": "You've learned to split your focus between multiple classes with ease. You gain a 2nd-level multiclass dedication feat, even if you normally couldn't take another dedication feat until you take more feats from your current archetype. If you're a half-elf, you don't need to meet the feat's ability score prerequisites.\r\n"
         },
         {
             "name": "Shory Aeromancer",
@@ -3844,13 +3990,10 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=955",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity",
             "benefits": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you.",
-            "text": [
-                "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level ",
-                " on yourself as an innate arcane spell once per day."
-            ]
+            "text": "Your ancestors hailed from the flying cities of the Shory, and a few simple tricks have come down through the ages to you. You can cast 4th-level fly on yourself as an innate arcane spell once per day."
         },
         {
-            "name": "Virtue-Forged Tattooed",
+            "name": "Virtue-Forged Tattoos",
             "level": "9",
             "traits": [
                 "Human"
@@ -3858,10 +4001,29 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=956",
             "prereq": "Ornate Tattoo",
             "benefits": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin.",
-            "text": [
-                "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level ",
-                " spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
-            ]
+            "text": "Your tattoos are a work of eldritch genius, a masterpiece of art, magic, and skin. Choose a 3rd-level arcane spell from the same school as your Arcane Tattoos, either a common spell or another to which you have access, including a lower-level spell heightened to 3rd level if you wish. You can cast that spell once per day as an innate arcane spell."
+        },
+        {
+            "name": "Advanced General Training",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1440",
+            "prereq": "\u2014",
+            "benefits": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities.",
+            "text": "Over the course of adventuring, your adaptability has let you pick up numerous useful abilities. You gain a general feat of 7th level or lower. You must meet the feat's prerequisites."
+        },
+        {
+            "name": "Bounce Back",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1441",
+            "prereq": "\u2014",
+            "benefits": "You recover from near-death experiences with astounding resilience.",
+            "text": "You recover from near-death experiences with astounding resilience. Don't increase the value of your wounded condition due to losing the dying condition."
         },
         {
             "name": "Irriseni Ice-Witch",
@@ -3872,10 +4034,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=957",
             "prereq": "Jadwiga ethnicity, wintertouched human heritage",
             "benefits": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself.",
-            "text": [
-                "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level ",
-                " as an innate arcane spell once per day."
-            ]
+            "text": "You can trace your direct descent from one of the Queens of Irrisen and thus from Baba Yaga herself. Your resistance to cold increases to 5 + half your level, and you can cast 5th-level wall of ice as an innate arcane spell once per day."
         },
         {
             "name": "Shadow Pact",
@@ -3886,11 +4045,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=958",
             "prereq": "Nidalese ethnicity",
             "benefits": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon.",
-            "text": [
-                "Thousands of years ago, your ancestors made a pact with ",
-                ". He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level ",
-                " as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
-            ]
+            "text": "Thousands of years ago, your ancestors made a pact with Zon-Kuthon. He has not forgotten, even if you might wish he had. You can take 1 damage to mix blood and shadows to cast 5th-level creation as an innate divine spell. You can use this ability as often as you wish, but you can have only one such object in existence at a time. If the object encounters bright light, the spell ends and the object dissolves into shadows."
         },
         {
             "name": "Shory Aerialist",
@@ -3901,10 +4056,18 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=959",
             "prereq": "Garundi, Mauxi, or Tian-Yae ethnicity; Shory Aeromancer or ability to cast fly",
             "benefits": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air.",
-            "text": [
-                "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to ",
-                " checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
-            ]
+            "text": "Unique in Golarion\u2019s history, the Shory people developed fighting styles dedicated to combat in the air. You gain a +2 circumstance bonus to Acrobatics checks to Maneuver in Flight and a +5-foot status bonus to your fly Speed whenever you are flying via magic."
+        },
+        {
+            "name": "Stubborn Persistence",
+            "level": "13",
+            "traits": [
+                "Human"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1442",
+            "prereq": "\u2014",
+            "benefits": "Humans are renowned for their ability to persist through the most grueling of trials.",
+            "text": "Humans are renowned for their ability to persist through the most grueling of trials. When you would become fatigued, attempt a DC 17 flat check. On a success, you aren't fatigued. If the fatigued condition has an underlying cause that you don't address, such as lack of rest, you must attempt the check again at an interval determined by the GM until you fail the flat check or address the underlying cause."
         },
         {
             "name": "Unconventional Expertise",
@@ -3915,10 +4078,20 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=78",
             "prereq": "Unconventional Weaponry, trained in the weapon you chose for Unconventional Weaponry",
             "benefits": "You\u2019ve continued to advance your powers using your unconventional weapon.",
-            "text": [
-                "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for ",
-                "."
-            ]
+            "text": "You\u2019ve continued to advance your powers using your unconventional weapon. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the weapon you chose for Unconventional Weaponry."
+        },
+        {
+            "name": "Heroic Presence",
+            "level": "17",
+            "traits": [
+                "Human",
+                "Emotion",
+                "Mental"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1443",
+            "prereq": "\u2014",
+            "benefits": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve.",
+            "text": "The blood of heroes courses through your veins, and you inspire your allies to dig deep and find a new level of resolve. You grant up to 10 willing creatures within 30 feet the effects of a 6th-level zealous conviction, though the effect automatically ends on a target if you give that target a command they would normally find repugnant. This action has the auditory trait or visual trait, depending on how you inspire your allies."
         }
     ],
     " hobgoblinFeats": [
@@ -3931,11 +4104,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1024",
             "prereq": "\u2014",
             "benefits": "You learn formulas more easily.",
-            "text": [
-                "You learn formulas more easily. You gain four common 1st-level alchemical formulas when you take this feat, and each time you gain a level, you gain a common alchemical formula of that level. You still need ",
-                " to Craft alchemical items.",
-                " You can take this feat only at 1st level, and you can\u2019t retrain into or out of this feat."
-            ]
+            "text": "You learn formulas more easily. You gain four common 1st-level alchemical formulas when you take this feat, and each time you gain a level, you gain a common alchemical formula of that level. You still need Alchemical Crafting to Craft alchemical items."
         },
         {
             "name": "Hobgoblin Lore",
@@ -3946,12 +4115,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1025",
             "prereq": "\u2014",
             "benefits": "You\u2019ve studied traditional hobgoblin exercises and fieldcraft, all of which have a militaristic bent.",
-            "text": [
-                "You\u2019ve studied traditional hobgoblin exercises and fieldcraft, all of which have a militaristic bent. You become trained in ",
-                " and ",
-                ". For each of these skills in which you were already trained, you become trained in a skill of your choice. You also become trained in Hobgoblin ",
-                "."
-            ]
+            "text": "You\u2019ve studied traditional hobgoblin exercises and fieldcraft, all of which have a militaristic bent. You become trained in Athletics and Crafting. For each of these skills in which you were already trained, you become trained in a skill of your choice. You also become trained in Hobgoblin Lore."
         },
         {
             "name": "Hobgoblin Weapon Familiarity",
@@ -3962,9 +4126,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1026",
             "prereq": "\u2014",
             "benefits": "You are trained with composite longbows, composite shortbows, glaives, halberds, longbows, longspears, longswords, shortbows, and spears.",
-            "text": [
-                "You are trained with composite longbows, composite shortbows, glaives, halberds, longbows, longspears, longswords, shortbows, and spears. In addition, you gain access to all uncommon hobgoblin weapons. For the purpose of determining your proficiency, martial hobgoblin weapons are simple weapons and advanced hobgoblin weapons are martial weapons."
-            ]
+            "text": "You are trained with composite longbows, composite shortbows, glaives, halberds, longbows, longspears, longswords, shortbows, and spears. In addition, you gain access to all uncommon hobgoblin weapons. For the purpose of determining your proficiency, martial hobgoblin weapons are simple weapons and advanced hobgoblin weapons are martial weapons."
         },
         {
             "name": "Leech-Clipper",
@@ -3975,9 +4137,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1027",
             "prereq": "\u2014",
             "benefits": "You are trained to capture deserters, or \u201cleeches\u201d.",
-            "text": [
-                "You are trained to capture deserters, or \u201cleeches.\u201d If you critically hit a foe with a weapon from the flail weapon group, you can wrap the weapon around the target\u2019s legs and then drop it, causing the foe to take a \u201310-foot circumstance penalty to their Speeds until they or their allies disentangle the weapon, which takes a total of 2 Interact actions."
-            ]
+            "text": "You are trained to capture deserters, or \u201cleeches.\u201d If you critically hit a foe with a weapon from the flail weapon group, you can wrap the weapon around the target\u2019s legs and then drop it, causing the foe to take a \u201310-foot circumstance penalty to their Speeds until they or their allies disentangle the weapon, which takes a total of 2 Interact actions."
         },
         {
             "name": "Remorseless Lash",
@@ -3988,10 +4148,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1028",
             "prereq": "\u2014",
             "benefits": "You\u2019re skilled at beating a foe when their morale is already breaking.",
-            "text": [
-                "You\u2019re skilled at beating a foe when their morale is already breaking. When you succeed at a melee weapon Strike against a ",
-                " foe, that foe can\u2019t reduce their frightened condition below 1 until the beginning of your next turn."
-            ]
+            "text": "You\u2019re skilled at beating a foe when their morale is already breaking. When you succeed at a melee weapon Strike against a frightened foe, that foe can\u2019t reduce their frightened condition below 1 until the beginning of your next turn."
         },
         {
             "name": "Vigorous Health",
@@ -4002,10 +4159,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1029",
             "prereq": "\u2014",
             "benefits": "Your physique is robust and can withstand blood loss startlingly well.",
-            "text": [
-                "Your physique is robust and can withstand blood loss startlingly well. Whenever you would gain the ",
-                " condition, you can attempt a DC 17 flat check. On a success, you don\u2019t gain the drained condition."
-            ]
+            "text": "Your physique is robust and can withstand blood loss startlingly well. Whenever you would gain the drained condition, you can attempt a DC 17 flat check. On a success, you don\u2019t gain the drained condition."
         },
         {
             "name": "Agonizing Rebuke",
@@ -4016,12 +4170,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1030",
             "prereq": "\u2014",
             "benefits": "When you terrorize your enemies, you also cause them painful mental distress.",
-            "text": [
-                "When you terrorize your enemies, you also cause them painful mental distress. When you successfully ",
-                " a foe, that foe takes 1d4 mental damage at the start of each of its turns as long as it remains ",
-                " and continues to engage in combat with you. If you have master proficiency in ",
-                ", the damage increases to 2d4, and if you have legendary proficiency, the damage increases to 3d4."
-            ]
+            "text": "When you terrorize your enemies, you also cause them painful mental distress. When you successfully Demoralize a foe, that foe takes 1d4 mental damage at the start of each of its turns as long as it remains frightened and continues to engage in combat with you. If you have master proficiency in Intimidation, the damage increases to 2d4, and if you have legendary proficiency, the damage increases to 3d4."
         },
         {
             "name": "Expert Drill Sergeant",
@@ -4032,10 +4181,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1031",
             "prereq": "\u2014",
             "benefits": "You know how to get the most out of your allies.",
-            "text": [
-                "You know how to get the most out of your allies. While exploring, when you are leading and allies are ",
-                ", you grant a +3 circumstance bonus instead of +2 if you\u2019re an expert in the applicable skill, and a +4 circumstance bonus if you\u2019re a master."
-            ]
+            "text": "You know how to get the most out of your allies. While exploring, when you are leading and allies are Following the Expert, you grant a +3 circumstance bonus instead of +2 if you\u2019re an expert in the applicable skill, and a +4 circumstance bonus if you\u2019re a master."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Hobgoblin",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Formation Training",
@@ -4046,9 +4204,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1032",
             "prereq": "trained in all martial weapons",
             "benefits": "You know how to fight in formation with your brethren.",
-            "text": [
-                "You know how to fight in formation with your brethren. When you are adjacent to at least two hobgoblin allies, you gain a +1 circumstance bonus to AC and saving throws. This bonus increases to +2 on Reflex saves against area effects."
-            ]
+            "text": "You know how to fight in formation with your brethren. When you are adjacent to at least two hobgoblin allies, you gain a +1 circumstance bonus to AC and saving throws. This bonus increases to +2 on Reflex saves against area effects."
         },
         {
             "name": "Hobgoblin Weapon Discipline",
@@ -4059,9 +4215,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1033",
             "prereq": "Hobgoblin Weapon Familiarity",
             "benefits": "You know how to efficiently utilize the weapons soldiers use in close quarters.",
-            "text": [
-                "You know how to efficiently utilize the weapons soldiers use in close quarters. Whenever you score a critical hit using a weapon of the polearm, spear, or sword group, you apply the weapon\u2019s critical specialization effect."
-            ]
+            "text": "You know how to efficiently utilize the weapons soldiers use in close quarters. Whenever you score a critical hit using a weapon of the polearm, spear, or sword group, you apply the weapon\u2019s critical specialization effect."
         },
         {
             "name": "Pride in Arms",
@@ -4072,9 +4226,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1034",
             "prereq": "\u2014",
             "benefits": "With a shout of triumph, you grant inspiration to an ally fight on.",
-            "text": [
-                "With a shout of triumph, you grant inspiration to an ally fight on. The triggering ally gains temporary Hit Points equal to their Constitution modifier until the end of their next turn."
-            ]
+            "text": "With a shout of triumph, you grant inspiration to an ally fight on. The triggering ally gains temporary Hit Points equal to their Constitution modifier until the end of their next turn."
         },
         {
             "name": "Formation Master",
@@ -4085,9 +4237,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1035",
             "prereq": "Formation Training",
             "benefits": "You can assemble a formation even with members of ancestries that lack the hobgoblins\u2019 military discipline, and you can extend these benefits to your hobgoblin allies.",
-            "text": [
-                "You can assemble a formation even with members of ancestries that lack the hobgoblins\u2019 military discipline, and you can extend these benefits to your hobgoblin allies. When you are adjacent to at least two humanoid allies, you gain the benefits of Formation Training, even if they aren\u2019t hobgoblin allies. Hobgoblin allies adjacent to you and at least one other hobgoblin ally also gain the bonuses from your Formation Training feat."
-            ]
+            "text": "You can assemble a formation even with members of ancestries that lack the hobgoblins\u2019 military discipline, and you can extend these benefits to your hobgoblin allies. When you are adjacent to at least two humanoid allies, you gain the benefits of Formation Training, even if they aren\u2019t hobgoblin allies. Hobgoblin allies adjacent to you and at least one other hobgoblin ally also gain the bonuses from your Formation Training feat."
         },
         {
             "name": "Hobgoblin Weapon Expertise",
@@ -4098,9 +4248,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1036",
             "prereq": "Hobgoblin Weapon Familiarity",
             "benefits": "You increase your training in battlefield weapons.",
-            "text": [
-                "You increase your training in battlefield weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency rank in all weapons you are trained in from Hobgoblin Weapon Familiarity."
-            ]
+            "text": "You increase your training in battlefield weapons. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency rank in all weapons you are trained in from Hobgoblin Weapon Familiarity."
+        },
+        {
+            "name": "Azaersi's Roads",
+            "level": "17",
+            "traits": [
+                "Hobgoblin",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=2160",
+            "prereq": "\u2014",
+            "benefits": "Azaersi has granted you limited access to the Stone Roads, attuning you to the tiniest sliver of the Onyx Key.",
+            "text": "Azaersi has granted you limited access to the Stone Roads, attuning you to the tiniest sliver of the Onyx Key. You gain plane shift as a primal innate spell. You can cast it twice per week. This can be used only to travel back and forth between the Plane of Earth and the Material Plane. Due to your attunement to the Onyx Key, you can act as the spell focus, and you do not require a tuning fork.\r\n"
         }
     ],
     " leshyFeats": [
@@ -4113,9 +4273,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1037",
             "prereq": "\u2014",
             "benefits": "You can extend a tangle of vines or tendrils to support your arms and extend your reach.",
-            "text": [
-                "You can extend a tangle of vines or tendrils to support your arms and extend your reach. When you wield a melee weapon that requires two hands, doesn\u2019t have reach, and deals at least 1d6 damage, you can change between a typical two-handed grip and an extended two-handed grasp using an Interact action. Weapons wielded in your extended grasp gain reach of 10 feet. This grasp is less stable and powerful than a typical grip, reducing the weapon\u2019s damage die by 1 step."
-            ]
+            "text": "You can extend a tangle of vines or tendrils to support your arms and extend your reach. When you wield a melee weapon that requires two hands, doesn\u2019t have reach, and deals at least 1d6 damage, you can change between a typical two-handed grip and an extended two-handed grasp using an Interact action. Weapons wielded in your extended grasp gain reach of 10 feet. This grasp is less stable and powerful than a typical grip, reducing the weapon\u2019s damage die by 1 step."
         },
         {
             "name": "Harmlessly Cute",
@@ -4126,11 +4284,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1038",
             "prereq": "\u2014",
             "benefits": "Your size and demeanor make it easy for you to convince others that you mean no harm.",
-            "text": [
-                "Your size and demeanor make it easy for you to convince others that you mean no harm. You gain the ",
-                " skill feat as a bonus feat. Additionally, you gain a +1 circumstance bonus to initiative checks when you roll ",
-                " for initiative."
-            ]
+            "text": "Your size and demeanor make it easy for you to convince others that you mean no harm. You gain the Shameless Request skill feat as a bonus feat. Additionally, you gain a +1 circumstance bonus to initiative checks when you roll Deception for initiative."
         },
         {
             "name": "Leshy Lore",
@@ -4141,12 +4295,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1039",
             "prereq": "\u2014",
             "benefits": "You deeply understand your people\u2019s cultural traditions and innate strengths.",
-            "text": [
-                "You deeply understand your people\u2019s cultural traditions and innate strengths. You gain the trained proficiency rank in ",
-                " and ",
-                ". If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Leshy ",
-                "."
-            ]
+            "text": "You deeply understand your people\u2019s cultural traditions and innate strengths. You gain the trained proficiency rank in Nature and Stealth. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Leshy Lore."
         },
         {
             "name": "Leshy Superstition",
@@ -4157,9 +4306,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1040",
             "prereq": "\u2014",
             "benefits": "You notice spirits that inhabit objects, learning which bring good fortune and which are unlucky.",
-            "text": [
-                "You notice spirits that inhabit objects, learning which bring good fortune and which are unlucky. You focus on the power of a lucky object, granting you a +1 circumstance bonus to your saving throw against the triggering effect."
-            ]
+            "text": "You notice spirits that inhabit objects, learning which bring good fortune and which are unlucky. You focus on the power of a lucky object, granting you a +1 circumstance bonus to your saving throw against the triggering effect."
         },
         {
             "name": "Seedpod",
@@ -4170,10 +4317,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1041",
             "prereq": "\u2014",
             "benefits": "Your body produces a nearly endless supply of hard seedpods.",
-            "text": [
-                "Your body produces a nearly endless supply of hard seedpods. You gain a seedpod ranged unarmed attack that deals 1d4 bludgeoning damage; these Strikes have the ",
-                " trait. On a critical hit, a seedpod bursts, issuing forth a tangle of vegetation that imposes a \u201310-foot circumstance penalty on the target\u2019s Speed for 1 round. Seedpods do not add critical specialization effects."
-            ]
+            "text": "Your body produces a nearly endless supply of hard seedpods. You gain a seedpod ranged unarmed attack that deals 1d4 bludgeoning damage; these Strikes have the manipulate trait. On a critical hit, a seedpod bursts, issuing forth a tangle of vegetation that imposes a \u201310-foot circumstance penalty on the target\u2019s Speed for 1 round. Seedpods do not add critical specialization effects."
         },
         {
             "name": "Shadow of the Wilds",
@@ -4184,10 +4328,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1042",
             "prereq": "\u2014",
             "benefits": "It\u2019s difficult to notice your passage through wild areas.",
-            "text": [
-                "It\u2019s difficult to notice your passage through wild areas. As long as you\u2019re not in an urban environment, you\u2019re always considered to be ",
-                ", even if you chose a different activity in exploration mode."
-            ]
+            "text": "It\u2019s difficult to notice your passage through wild areas. As long as you\u2019re not in an urban environment, you\u2019re always considered to be Covering Tracks, even if you chose a different activity in exploration mode."
         },
         {
             "name": "Undaunted",
@@ -4198,10 +4339,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1043",
             "prereq": "\u2014",
             "benefits": "Your spirit has endured many challenges over its long existence, and you are certain you can overcome whatever hardships life throws your way.",
-            "text": [
-                "Your spirit has endured many challenges over its long existence, and you are certain you can overcome whatever hardships life throws your way. You gain a +1 circumstance bonus to saves against ",
-                " effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead."
-            ]
+            "text": "Your spirit has endured many challenges over its long existence, and you are certain you can overcome whatever hardships life throws your way. You gain a +1 circumstance bonus to saves against emotion effects. If you roll a success on a saving throw against an emotion effect, you get a critical success instead."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Leshy",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Leshy Glide",
@@ -4212,26 +4362,21 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1044",
             "prereq": "leaf leshy heritage or Cat Fall skill feat",
             "benefits": "Using your own leaves, you can control your descent.",
-            "text": [
-                "Using your own leaves, you can control your descent. You glide slowly toward the ground, 5 feet down and up to 25 feet forward through the air. As long as you spend at least 1 action gliding each round and have not yet reached the ground, you remain in the air at the end of your turn."
-            ]
+            "text": "Using your own leaves, you can control your descent. You glide slowly toward the ground, 5 feet down and up to 25 feet forward through the air. As long as you spend at least 1 action gliding each round and have not yet reached the ground, you remain in the air at the end of your turn."
         },
         {
             "name": "Ritual Reversion",
             "level": "5",
             "traits": [
                 "Leshy",
-                " Polymorph",
-                " Primal",
-                " Transmutation"
+                "Polymorph",
+                "Primal",
+                "Transmutation"
             ],
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1045",
             "prereq": "\u2014",
             "benefits": "You can temporarily revert to a less conspicuous form without diminishing your senses.",
-            "text": [
-                "You can temporarily revert to a less conspicuous form without diminishing your senses. You take the form of an ordinary specimen of the type of plant or fungus that most closely resembles you, reverting to your body\u2019s appearance just before your spirit joined with it. This otherwise has the effects of ",
-                ", except that your size remains Small."
-            ]
+            "text": "You can temporarily revert to a less conspicuous form without diminishing your senses. You take the form of an ordinary specimen of the type of plant or fungus that most closely resembles you, reverting to your body\u2019s appearance just before your spirit joined with it. This otherwise has the effects of tree shape, except that your size remains Small."
         },
         {
             "name": "Speak with Kindred",
@@ -4242,10 +4387,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1046",
             "prereq": "\u2014",
             "benefits": "You have a connection with creatures that share your physiology.",
-            "text": [
-                "You have a connection with creatures that share your physiology. You can ask questions of, receive answers from, and use the ",
-                " skill with plants or fungi that match your leshy heritage. Generally, fungus leshies can speak to mushrooms and fungi; gourd leshies can speak to gourds, melons, and similar fruiting plants; leaf leshies can speak with deciduous trees; and vine leshies can speak with vines and climbing plants. The GM determines which plants or fungi count for this ability."
-            ]
+            "text": "You have a connection with creatures that share your physiology. You can ask questions of, receive answers from, and use the Diplomacy skill with plants or fungi that match your leshy heritage. Generally, fungus leshies can speak to mushrooms and fungi; gourd leshies can speak to gourds, melons, and similar fruiting plants; leaf leshies can speak with deciduous trees; and vine leshies can speak with vines and climbing plants. The GM determines which plants or fungi count for this ability."
         },
         {
             "name": "Bark and Tendril",
@@ -4256,11 +4398,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1047",
             "prereq": "\u2014",
             "benefits": "You wield primal magic.",
-            "text": [
-                "You wield primal magic. You can cast ",
-                " and ",
-                " as 2nd-level primal innate spells once per day each."
-            ]
+            "text": "You wield primal magic. You can cast barkskin and entangle as 2nd-level primal innate spells once per day each."
         },
         {
             "name": "Lucky Keepsake",
@@ -4271,9 +4409,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1048",
             "prereq": "Leshy Superstition",
             "benefits": "You have a keepsake that grants you luck.",
-            "text": [
-                "You have a keepsake that grants you luck. You gain a +1 circumstance bonus to saves against spells and magical effects at all times, not just when you use Leshy Superstition. If you lose the keepsake, you lose the bonus until you designate a new keepsake, typically over the course of a week."
-            ]
+            "text": "You have a keepsake that grants you luck. You gain a +1 circumstance bonus to saves against spells and magical effects at all times, not just when you use Leshy Superstition. If you lose the keepsake, you lose the bonus until you designate a new keepsake, typically over the course of a week."
         },
         {
             "name": "Solar Rejuvenation",
@@ -4284,10 +4420,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1049",
             "prereq": "\u2014",
             "benefits": "If you rest outdoors for 10 minutes during the day, you regain Hit Points equal to your Constitution modifier \u00d7 half your level.",
-            "text": [
-                "If you rest outdoors for 10 minutes during the day, you regain Hit Points equal to your Constitution modifier \u00d7 half your level. You gain this benefit in addition to any healing from ",
-                ". Leshies whose plant nourishment does not rely on photosynthesis require a similarly suitable environment. For example, fungus leshies need dark, damp environments and a pile of decaying plant matter."
-            ]
+            "text": "If you rest outdoors for 10 minutes during the day, you regain Hit Points equal to your Constitution modifier \u00d7 half your level. You gain this benefit in addition to any healing from Treat Wounds. Leshies whose plant nourishment does not rely on photosynthesis require a similarly suitable environment. For example, fungus leshies need dark, damp environments and a pile of decaying plant matter."
         }
     ],
     " lizardfolkFeats": [
@@ -4300,12 +4433,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1050",
             "prereq": "\u2014",
             "benefits": "You listened carefully to the tales passed down among your community.",
-            "text": [
-                "You listened carefully to the tales passed down among your community. You gain the trained proficiency rank in ",
-                " and ",
-                ". If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Iruxi ",
-                "."
-            ]
+            "text": "You listened carefully to the tales passed down among your community. You gain the trained proficiency rank in Nature and Survival. If you would automatically become trained in one of those skills (from your background or class, for example), you instead become trained in a skill of your choice. You also become trained in Iruxi Lore."
         },
         {
             "name": "Marsh Runner",
@@ -4316,10 +4444,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1051",
             "prereq": "You have a swim Speed.",
             "benefits": "You are adept at moving through marshy terrain.",
-            "text": [
-                "You are adept at moving through marshy terrain. When you use the Step action, you can ignore difficult terrain caused by flooding, swamps, or quicksand. In addition, when you use the ",
-                " skill to Balance on narrow surfaces or uneven marshy ground, you aren\u2019t flat-footed, and if you roll a success on the Acrobatics check, you get a critical success instead."
-            ]
+            "text": "You are adept at moving through marshy terrain. When you use the Step action, you can ignore difficult terrain caused by flooding, swamps, or quicksand. In addition, when you use the Acrobatics skill to Balance on narrow surfaces or uneven marshy ground, you aren\u2019t flat-footed, and if you roll a success on the Acrobatics check, you get a critical success instead."
         },
         {
             "name": "Parthenogenic Hatchling",
@@ -4330,9 +4455,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1052",
             "prereq": "\u2014",
             "benefits": "You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother.",
-            "text": [
-                "You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother. You gain a +1 circumstance bonus to saving throws against diseases. Each of your successful saving throws against a disease reduces its stage by 2, or by 1 for a virulent disease. Each critical success against an ongoing disease reduces its stage by 3, or by 2 for a virulent disease. You take damage only every 2 hours from thirst and every 2 days from starvation, rather than every hour and every day."
-            ]
+            "text": "You were hatched from an unfertilized egg during hard times for your people, and you are a biological copy of your mother. You gain a +1 circumstance bonus to saving throws against diseases. Each of your successful saving throws against a disease reduces its stage by 2, or by 1 for a virulent disease. Each critical success against an ongoing disease reduces its stage by 3, or by 2 for a virulent disease. You take damage only every 2 hours from thirst and every 2 days from starvation, rather than every hour and every day."
         },
         {
             "name": "Razor Claws",
@@ -4343,10 +4466,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1053",
             "prereq": "\u2014",
             "benefits": "Your have honed your claws to be deadly.",
-            "text": [
-                "Your have honed your claws to be deadly. Your claw attack deals 1d6 slashing damage instead of 1d4 and gains the ",
-                " (piercing) trait."
-            ]
+            "text": "Your have honed your claws to be deadly. Your claw attack deals 1d6 slashing damage instead of 1d4 and gains the versatile (piercing) trait."
         },
         {
             "name": "Reptile Speaker",
@@ -4357,10 +4477,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1054",
             "prereq": "\u2014",
             "benefits": "You hear the sounds of reptiles as language.",
-            "text": [
-                "You hear the sounds of reptiles as language. You can ask questions of, receive answers from, and use the ",
-                " skill with animals that are reptiles (the GM determines which animals count as reptiles)."
-            ]
+            "text": "You hear the sounds of reptiles as language. You can ask questions of, receive answers from, and use the Diplomacy skill with animals that are reptiles (the GM determines which animals count as reptiles)."
         },
         {
             "name": "Sharp Fangs",
@@ -4371,9 +4488,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1055",
             "prereq": "\u2014",
             "benefits": "Your teeth are formidable weapons.",
-            "text": [
-                "Your teeth are formidable weapons. You gain a fangs unarmed attack that deals 1d8 piercing damage."
-            ]
+            "text": "Your teeth are formidable weapons. You gain a fangs unarmed attack that deals 1d8 piercing damage."
         },
         {
             "name": "Tail Whip",
@@ -4384,9 +4499,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1056",
             "prereq": "\u2014",
             "benefits": "By birth or through training, your tail is strong enough to make for a powerful melee weapon.",
-            "text": [
-                "By birth or through training, your tail is strong enough to make for a powerful melee weapon. You gain a tail unarmed attack that deals 1d6 bludgeoning damage and has the sweep trait."
-            ]
+            "text": "By birth or through training, your tail is strong enough to make for a powerful melee weapon. You gain a tail unarmed attack that deals 1d6 bludgeoning damage and has the sweep trait."
         },
         {
             "name": "Envenom Fangs",
@@ -4397,9 +4510,19 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1057",
             "prereq": "Sharp Fangs",
             "benefits": "You envenom your fangs.",
-            "text": [
-                "You envenom your fangs. If the next fangs Strike you make before the end of your next turn hits and deals damage, the Strike deals an additional 1d6 poison damage. On a critical failure, the poison is wasted as normal."
-            ]
+            "text": "You envenom your fangs. If the next fangs Strike you make before the end of your next turn hits and deals damage, the Strike deals an additional 1d6 poison damage. On a critical failure, the poison is wasted as normal."
+        },
+        {
+            "name": "Fey Influence",
+            "level": "5",
+            "traits": [
+                "Lizardfolk",
+                "Rare"
+            ],
+            "link": "https://2e.aonprd.com/Feats.aspx?ID=1239",
+            "prereq": "\u2014",
+            "benefits": "Your exposure to fey influence has given you some primal magic",
+            "text": "You have been exposed to powerful fey magic. You become trained in primal DCs and spell attack rolls. You gain the fey trait and one of the following features which grant an innate primal spell that can be used once per day. Anteater You can launch your tongue forward as a deadly attack, gaining grim tendrils.Dryad Your body is covered in elegant vines, granting you summon plants or fungus.Gremlin You have long, bat-like ears and gain bane.Monarch You have vestigial, insectile features and gain spider sting. This feat gains the trait appropriate for your ancestry (human for human, goblin for goblin, etc.)"
         },
         {
             "name": "Gecko's Grip",
@@ -4410,9 +4533,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1058",
             "prereq": "cliffscale lizardfolk",
             "benefits": "You stick to walls with a preternatural grip.",
-            "text": [
-                "You stick to walls with a preternatural grip. You gain a climb Speed of 15 feet."
-            ]
+            "text": "You stick to walls with a preternatural grip. You gain a climb Speed of 15 feet."
         },
         {
             "name": "Iruxi Unarmed Cunning",
@@ -4423,9 +4544,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1059",
             "prereq": "\u2014",
             "benefits": "You make the most of your iruxi unarmed attacks.",
-            "text": [
-                "You make the most of your iruxi unarmed attacks. Whenever you score a critical hit with a claw or an unarmed attack you gained from a lizardfolk ancestry feat, you apply the unarmed attack\u2019s critical specialization effect."
-            ]
+            "text": "You make the most of your iruxi unarmed attacks. Whenever you score a critical hit with a claw or an unarmed attack you gained from a lizardfolk ancestry feat, you apply the unarmed attack\u2019s critical specialization effect."
         },
         {
             "name": "Shed Tail",
@@ -4436,9 +4555,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1060",
             "prereq": "Tail Whip",
             "benefits": "You can shed your tail to escape.",
-            "text": [
-                "You can shed your tail to escape. You cease being grabbed, then Stride without triggering any reactions from the creature that grabbed you. It takes 1 week for your tail to fully grow back. Until it does, you can\u2019t use your tail unarmed attack, and you take a \u20132 circumstance penalty on checks to Balance."
-            ]
+            "text": "You can shed your tail to escape. You cease being grabbed, then Stride without triggering any reactions from the creature that grabbed you. It takes 1 week for your tail to fully grow back. Until it does, you can\u2019t use your tail unarmed attack, and you take a \u20132 circumstance penalty on checks to Balance."
         },
         {
             "name": "Swift Swimmer",
@@ -4449,9 +4566,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1061",
             "prereq": "wetlander lizardfolk",
             "benefits": "You swim faster than most iruxi.",
-            "text": [
-                "You swim faster than most iruxi. Your swim Speed increases to 25 feet."
-            ]
+            "text": "You swim faster than most iruxi. Your swim Speed increases to 25 feet."
         },
         {
             "name": "Terrain Advantage",
@@ -4462,10 +4577,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1062",
             "prereq": "\u2014",
             "benefits": "You can take advantage of the terrain to bypass foes\u2019 defenses.",
-            "text": [
-                "You can take advantage of the terrain to bypass foes\u2019 defenses. Non-lizardfolk creatures in difficult terrain are ",
-                " to you. If you have a swim Speed, non-lizardfolk creatures that are in water and lack a swim Speed are also flat-footed to you."
-            ]
+            "text": "You can take advantage of the terrain to bypass foes\u2019 defenses. Non-lizardfolk creatures in difficult terrain are flat-footed to you. If you have a swim Speed, non-lizardfolk creatures that are in water and lack a swim Speed are also flat-footed to you."
         },
         {
             "name": "Iruxi Unarmed Expertise",
@@ -4476,9 +4588,7 @@
             "link": "https://2e.aonprd.com/Feats.aspx?ID=1063",
             "prereq": "Iruxi Unarmed Cunning",
             "benefits": "Your unarmed attacks blend tradition and training.",
-            "text": [
-                "Your unarmed attacks blend tradition and training. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the claw and unarmed attacks you gained from lizardfolk ancestry feats."
-            ]
+            "text": "Your unarmed attacks blend tradition and training. Whenever you gain a class feature that grants you expert or greater proficiency in certain weapons, you also gain that proficiency in the claw and unarmed attacks you gained from lizardfolk ancestry feats."
         }
     ]
 }


### PR DESCRIPTION
Right now AON's formatting breaks the Ancestry builder (among other things, as the readme mentions).  This patch only fixes the Ancestry builder, but I intend to get all the data into a presently-usable condition so that it can be be used in another CUP project.  