### PR TITLE
Backgrounds from AoN (CUP)

### DIFF
--- a/backgrounds_aon-pf2.json
+++ b/backgrounds_aon-pf2.json
@@ -1,0 +1,3977 @@
+{
+    "name": "Pathfinder 2.0 background list",
+    "date": "January 15, 2021",
+    "General": [
+        {
+            "name": "Acolyte",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=1",
+            "prerequisites": "",
+            "description": "You spent your early days in a religious monastery or cloister. You may have traveled out into the world to spread the message of your religion or because you cast away the teachings of your faith, but deep down you'll always carry within you the lessons you learned. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Religion skill, and the Scribing Lore skill. You gain the Student of the Canon skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Scribing Lore"
+            ],
+            "featsGained": [
+                "Student of the Canon"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Acrobat",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=2",
+            "prerequisites": "",
+            "description": "In a circus or on the streets, you earned your pay by performing as an acrobat. You might have turned to adventuring when the money dried up, or simply decided to put your skills to better use. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Acrobatics skill, and the Circus Lore skill. You gain the Steady Balance skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Circus Lore"
+            ],
+            "featsGained": [
+                "Steady Balance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Amnesiac",
+            "source": "Advanced Player's Guide pg. 50",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=182",
+            "prerequisites": "",
+            "description": "Your background is... well... honestly, you can't remember! You might have inklings deep within your mind, undercurrents of unusual emotions or unexpected responses to certain people or situations, but ultimately you don't know who you once were. You might be adventuring specifically to help discover yourself. It's up to you and the GM how to handle the truth of your character's backstory. You could leave it to the GM so it's a secret, work together with the GM, or even choose to leave it undecided until later. In any case, you and your GM should determine a few noteworthy details about your character or their belongings to get the first clues to your past.  You gain three free ability boosts. You choose two, and the GM chooses the third based on their first inklings of your character's possible history.",
+            "abilityBoosts": [],
+            "skillsTrained": [],
+            "featsGained": [],
+            "descSpecial": {}
+        },
+        {
+            "name": "Animal Whisperer",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=3",
+            "prerequisites": "",
+            "description": "You have always felt a connection to animals, and it was only a small leap to learn to train them. As you travel, you continuously encounter different creatures, befriending them along the way. Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Nature skill, and a Lore skill related to one terrain inhabited by animals you like (such as Plains Lore or Swamp Lore). You gain the Train Animal skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Lore"
+            ],
+            "featsGained": [
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Archaeologist",
+            "source": "Pathfinder Society Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=202",
+            "prerequisites": "",
+            "description": "You've excavated enough sites to know that ancient civilizations aren't lost; they're merely buried and waiting for the right scholar to unearth them and tell their story. You might have worked as a laborer or local guide before learning formal archaeological techniques. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Architecture Lore skill. You gain the Additional Lore skill feat related to an ancient culture or the history of a culture you've studied (such as Azlanti Lore or Osirian History Lore).",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Architecture Lore"
+            ],
+            "featsGained": [
+                "Additional Lore"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Artisan",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=4",
+            "prerequisites": "",
+            "description": "As an apprentice, you practiced a particular form of building or crafting, developing specialized skill. You might have been a blacksmith's apprentice toiling over the forge for countless hours, a young tailor sewing garments of all kinds, or a shipwright shaping the hulls of ships. Choose two ability boosts. One must be to Strength or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Guild Lore skill. You gain the Specialty Crafting skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Guild Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Artist",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=5",
+            "prerequisites": "",
+            "description": "Your art is your greatest passion, whatever form it takes. Adventuring might help you find inspiration, or simply be a way to survive until you become a world-famous artist. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Crafting skill, and the Art Lore skill. You gain the Specialty Crafting skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Art Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bandit",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=165",
+            "prerequisites": "",
+            "description": "Your past includes no small amount of rural banditry, robbing travelers on the road and scraping by. Whether your robbery was sanctioned by a local noble or you did so of your own accord, you eventually got caught up in the adventuring life. Now, adventure is your stock and trade, and years of camping and skirmishing have only helped. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and a Lore skill related to the terrain you worked in (such as Desert Lore or Plains Lore). You gain the Group Coercion skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Barber",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=166",
+            "prerequisites": "",
+            "description": "Haircuts, dentistry, bloodletting, and surgery-if it takes a steady hand and a razor, you do it. You may have taken to the road to expand your skills, or to test yourself against a world that leaves your patients so battered and bruised. Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Medicine skill, and the Surgery Lore skill. You gain the Risky Surgery skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Surgery Lore"
+            ],
+            "featsGained": [
+                "Risky Surgery"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Barkeep",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=6",
+            "prerequisites": "",
+            "description": "You have five specialties: hefting barrels, drinking, polishing steins, drinking, and drinking. You worked in a bar, where you learned how to hold your liquor and rowdily socialize. Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Alcohol Lore skill. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Alcohol Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Barrister",
+            "source": "Core Rulebook pg. 60",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=7",
+            "prerequisites": "",
+            "description": "Piles of legal manuals, stern teachers, and experience in the courtroom have instructed you in legal matters. You're capable of mounting a prosecution or defense in court, and you tend to keep abreast of local laws, as you never can tell when you might need to know them on short notice. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Legal Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Legal Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Blessed",
+            "source": "Advanced Player's Guide pg. 50",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=183",
+            "prerequisites": "",
+            "description": "You have been blessed by a divinity. For an unknown reason, and irrespective of your actual beliefs, a deity has granted you a boon to use for good or ill. Your blessing grants wisdom and insight to aid you in your struggles. You may or may not even know the identity of the being who blessed you, and the blessing might come with a cost you discover later on.  Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost.  You are trained in a Lore skill associated with the deity who blessed you (such as Shelyn Lore) if you know their identity, or else in a Lore skill of the GM's choice if you don't. Either you can cast guidance as a divine innate spell at will, or you gain a similar blessing determined by the GM.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Lore"
+            ],
+            "featsGained": [],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bookkeeper",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=167",
+            "prerequisites": "",
+            "description": "You ran the numbers on a large farm, for a merchant's endeavors, or with a major guild in the city. You kept track of expenses, payroll, profits, and anything else that had to do with money, for better or worse. If better, you might be adventuring to learn how others ply this trade. If worse, you may be fleeing from impending consequences, in the hope that no one finds you. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Society skill, and the Accounting Lore skill. You gain the Eye for Numbers skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Accounting Lore"
+            ],
+            "featsGained": [
+                "Eye for Numbers"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bounty Hunter",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=8",
+            "prerequisites": "",
+            "description": "Bringing in lawbreakers lined your pockets. Maybe you had an altruistic motive and sought to bring in criminals to make the streets safer, or maybe the coin was motivation enough. Your techniques for hunting down criminals transfer easily to the life of an adventurer. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Legal Lore skill. You gain the Experienced Tracker skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Legal Lore"
+            ],
+            "featsGained": [
+                "Experienced Tracker"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Charlatan",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=9",
+            "prerequisites": "",
+            "description": "You traveled from place to place, peddling false fortunes and snake oil in one town, pretending to be royalty in exile to seduce a wealthy heir in the next. Becoming an adventurer might be your next big scam or an attempt to put your talents to use for a greater cause. Perhaps it's a bit of both, as you realize that after pretending to be a hero, you've become the mask. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Deception skill, and the Underworld Lore skill. You gain the Charming Liar skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Charming Liar"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Cook",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=168",
+            "prerequisites": "",
+            "description": "You grew up in the kitchens of a tavern or other dining establishment and excelled there, becoming an exceptional cook. Baking, cooking, a little brewing on the side-you've spent lots of time out of sight. It's about time you went out into the world to catch some sights for yourself. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Survival skill, and the Cooking Lore skill. You gain the Seasoned skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Cooking Lore"
+            ],
+            "featsGained": [
+                "Seasoned"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Courier",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=169",
+            "prerequisites": "",
+            "description": "In your youth, you earned coin running messages for persons of wealth and influence, darting through crowded cobblestone streets. Your dogged commitment to deliver your message was good training for the life of an adventurer. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Society skill, and a Lore skill for the city in which you were raised. You gain the Glean Contents skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Lore"
+            ],
+            "featsGained": [
+                "Glean Contents"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Criminal",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=10",
+            "prerequisites": "",
+            "description": "As an unscrupulous independent or as a member of an underworld organization, you lived a life of crime. You might have become an adventurer to seek redemption, to escape the law, or simply to get access to bigger and better loot. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Stealth skill, and the Underworld Lore skill. You gain the Experienced Smuggler skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Experienced Smuggler"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Cultist",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=170",
+            "prerequisites": "",
+            "description": "You were (or still are) a member of a cult whose rites may involve sacred dances to ensure a strong harvest or dire rituals that call upon dark powers. You might have taken up adventuring to further your cult's aims, to initiate yourself into the world's grander mysteries, or to flee unsavory practices or strictures. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Occultism skill, and a Lore skill related to your deity or cult. You gain the Schooled in Secrets skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Lore"
+            ],
+            "featsGained": [
+                "Schooled in Secrets"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Cursed",
+            "source": "Advanced Player's Guide pg. 50",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=184",
+            "prerequisites": "",
+            "description": "You are the victim of a personal or hereditary curse. Through great effort and occult study, you have learned to fend off the curse's worst effects and, by extension, you can protect yourself against other harmful magic. However, the curse still hangs over you and sometimes manifests in dangerous ways.  Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost.  You are trained in Occultism and Curse Lore. You gain the Warding Sign reaction. You and the GM should determine the full effects of the curse, though you've staved most of them off for now. The GM determines the curse's lingering manifestations on you, which usually include at least a constant or very frequent thematic effect and occasional more dangerous effects.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Curse Lore"
+            ],
+            "featsGained": [],
+            "descSpecial": {
+                "specType": "Activate",
+                "specAction": "Reaction",
+                "specDescription": [
+                    "Activate  (Concentrate) Warding Sign; Frequency once per minute; Trigger You attempt a saving throw against a magical effect, but you haven't rolled yet; Effect You call on the power of a personal, eldritch sign of protection, which flares brightly before slowly fading. You gain a +2 circumstance bonus to the triggering saving throw, or a +3 circumstance bonus if the effect is a curse."
+                ],
+                "specTrait": "Concentrate"
+            }
+        },
+        {
+            "name": "Deckhand",
+            "source": "Pathfinder Beginner Box: Hero's Handbook pg. 18",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=209",
+            "prerequisites": "",
+            "description": "The rolling waves of the high seas, the constant sway of the deck underfoot, and the creaking heights of a ship's rigging are as familiar to you as solid ground. You might have worked on a simple fishing boat, a wealthy merchant's galley, a mighty warship-or even a pirate's caravel. Whether your crew retired, your ship sank, or you've turned to adventuring so you can keep all the treasure for yourself, you still retain an excellent sense of balance and quick reflexes. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Acrobatics skill, and the Sailing Lore skill. You gain the Cat Fall skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Cat Fall"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Detective",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=11",
+            "prerequisites": "",
+            "description": "You solved crimes as a police inspector or took jobs for wealthy clients as a private investigator. You might have become an adventurer as part of your next big mystery, but likely it was due to the consequences or aftermath of a prior case. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Society skill, and the Underworld Lore skill. You gain the Streetwise skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Streetwise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Dreamer of the Verdant Moon",
+            "source": "Pathfinder #153: Life's Long Shadow pg. 67",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=144",
+            "prerequisites": "",
+            "description": "You spent your early days in the aftermath of one of the great ravenings. You survived thanks to your resourcefulness and perhaps your patron's favor and were blessed with skills and drive thereafter, but you must always hold to his standards, lest the hunger from the depths seek you out once again. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Zevgavizeb Lore skill. You gain the Ravening's Desperation skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Zevgavizeb Lore"
+            ],
+            "featsGained": [
+                "Ravening's Desperation"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Droskari Disciple",
+            "source": "Pathfinder #148: Fires of the Haunted City pg. 65",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=126",
+            "prerequisites": "",
+            "description": "You grew up in the church of the Dark Smith, where you learned the value of hard work and achieving vocational mastery.  Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost.  You gain the Skill Training skill feat, and you're trained in the Droskar Lore skill.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Droskar Lore"
+            ],
+            "featsGained": [
+                "Skill Training"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Emissary",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=12",
+            "prerequisites": "",
+            "description": "As a diplomat or messenger, you traveled to lands far and wide. Communicating with new people and forming alliances were your stock and trade. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Society skill, and a Lore skill related to one city you've visited often. You gain the Multilingual skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Lore"
+            ],
+            "featsGained": [
+                "Multilingual"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Entertainer",
+            "source": "Core Rulebook pg. 61",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=13",
+            "prerequisites": "",
+            "description": "Through an education in the arts or sheer dogged practice, you learned to entertain crowds. You might have been an actor, a dancer, a musician, a street magician, or any other sort of performer. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Theater Lore skill. You gain the Fascinating Performance skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Theater Lore"
+            ],
+            "featsGained": [
+                "Fascinating Performance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Farmhand",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=14",
+            "prerequisites": "",
+            "description": "With a strong back and an understanding of seasonal cycles, you tilled the land and tended crops. Your farm could have been razed by invaders, you could have lost the family tying you to the land, or you might have simply tired of the drudgery, but at some point you became an adventurer. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Athletics skill, and the Farming Lore skill. You gain the Assurance skill feat with Athletics.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Farming Lore",
+                "Athletics"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Feral Child",
+            "source": "Advanced Player's Guide pg. 50",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=185",
+            "prerequisites": "",
+            "description": "You spent your youth in the wilderness, living close to or perhaps raised by animals. You have a close, mystical connection with these animals and gained certain abilities from them, though this limited your well-roundedness in mental pursuits.  Choose one ability boost. It must be Strength, Dexterity, or Constitution.  You are trained in Nature and Survival. You gain low-light vision (or darkvision if you already had low-light vision), imprecise scent with a range of 30 feet, and the Forager skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Survival"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Feybound",
+            "source": "Advanced Player's Guide pg. 50",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=186",
+            "prerequisites": "",
+            "description": "You have spent time in the First World or another realm of the fey and aren't entirely the same person you were before. Perhaps you made a purchase at the legendary Witchmarket or partook deeply of fey food and wine. Whatever the case, willingly or inadvertently, you made a bargain with the fey, the benefits of which come at a price.  Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost.  You are trained in Fey Lore and gain the Fey's Fortune free action. You must follow some rule or limitation as part of your pact with the fey. If you violate the rule, you lose Fey's Fortune until you receive the effects of a successful atone ritual using the Nature skill. The exact limitation is up to you and the GM, but the most common requirement is that you must fulfill a single request from any fey who knows your name.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Fey Lore",
+                "Nature"
+            ],
+            "featsGained": [],
+            "descSpecial": {
+                "specType": "Activate",
+                "specAction": "Free Action",
+                "specDescription": [
+                    "Activate  (Concentrate, Fortune) Fey's Fortune; Frequency once per day; Trigger You attempt a skill check and haven't yet rolled; Effect Roll the skill check twice and use the better result."
+                ],
+                "specTrait": "Concentrate"
+            }
+        },
+        {
+            "name": "Field Medic",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=15",
+            "prerequisites": "",
+            "description": "In the chaotic rush of battle, you learned to adapt to rapidly changing conditions as you administered to battle casualties. You patched up soldiers, guards, or other combatants, and learned a fair amount about the logistics of war. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Medicine skill, and the Warfare Lore skill. You gain the Battle Medicine skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Battle Medicine"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Fortune Teller",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=16",
+            "prerequisites": "",
+            "description": "The strands of fate are clear to you, as you have learned many traditional forms by which laypeople can divine the future. You might have used these skills to guide your community, or simply to make money. But even the slightest peek into these practices connects you to the occult mysteries of the universe. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Occultism skill, and the Fortune-Telling Lore skill. You gain the Oddity Identification skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Fortune-Telling Lore"
+            ],
+            "featsGained": [
+                "Oddity Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Gambler",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=17",
+            "prerequisites": "",
+            "description": "The thrill of the win drew you into games of chance. This might have been a lucrative sideline that paled in comparison to the real risks of adventuring, or you might have fallen on hard times due to your gambling and pursued adventuring as a way out of a spiral. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Deception skill, and the Games Lore skill. You gain the Lie to Me skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Games Lore"
+            ],
+            "featsGained": [
+                "Lie to Me"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Gladiator",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=18",
+            "prerequisites": "",
+            "description": "The bloody games of the arena taught you the art of combat. Before you attained true fame, you departed-or escaped-the arena to explore the world. Your skill at drawing both blood and a crowd's attention pay off in a new adventuring life. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Gladiatorial Lore skill. You gain the Impressive Performance skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Gladiatorial Lore"
+            ],
+            "featsGained": [
+                "Impressive Performance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Guard",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=19",
+            "prerequisites": "",
+            "description": "You served in the guard, out of either patriotism or the need for coin. Either way, you know how to get a difficult suspect to talk. However you left the guard, you might think of adventuring as a way to use your skills on a wider stage. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Legal Lore skill or Warfare Lore skill. You gain the Quick Coercion skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Legal Lore"
+            ],
+            "featsGained": [
+                "Quick Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Harrow-Led",
+            "source": "Pathfinder #160: Assault on Hunting Lodge Seven pg. 66",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=200",
+            "prerequisites": "",
+            "description": "You were the subject of a harrow reading at a pivotal point in your life, such as on an important birthday, or upon reaching adulthood. The reading was eerily accurate and has been relevant, for good or ill, at more points in your life than you could call mere coincidence.  Randomly determine two harrow suits tied to your character, each reflecting a specific ability score. You can do so by drawing cards from a harrow deck or by rolling a d6: 1 = hammers (Strength), 2 = keys (Dexterity), 3 = shields (Constitution), 4 = books (Intelligence), 5 = stars (Wisdom), 6 = crowns (Charisma). The first suit is your aligned score, and the second suit is your misaligned score.  Choose two ability boosts. One must be to your aligned or misaligned score, and one is a free ability boost. You're trained in your choice of the Occultism, Performance, or Society skill and the Harrow Lore skill. You gain the Dubious Knowledge skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity",
+                "Constitution",
+                "Intelligence",
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Performance",
+                "Society",
+                "Harrow Lore"
+            ],
+            "featsGained": [
+                "Dubious Knowledge"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Haunted",
+            "source": "Advanced Player's Guide pg. 51",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=187",
+            "prerequisites": "",
+            "description": "You are followed by a spirit or entity, either from childhood or since a traumatic or momentous event. You may have seen this entity. Others may have seen it as well. You have studied esoteric subjects trying to understand your situation, but this presence in your life remains a mystery. Whatever this entity is or wants, it influences your life in subtle ways, not always good. Sometimes the entity helps you, but at other times, its influence is malevolent or harmful. The entity is most likely to surface in stressful situations.  Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost.  You are trained in Occultism and an additional skill in which the haunting entity is well-versed, determined by the GM. Any time you attempt a skill check for the entity's skill, the GM can offer you a +1 circumstance bonus to the check, as though the entity were Aiding you. If you accept but fail the check, you are frightened 2 (frightened 4 on a critical failure). The initial frightened value can't be reduced by effects that would reduce or prevent the condition (such as a fighter's bravery).",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism"
+            ],
+            "featsGained": [],
+            "descSpecial": {}
+        },
+        {
+            "name": "Herbalist",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=20",
+            "prerequisites": "",
+            "description": "As a formally trained apothecary or a rural practitioner of folk medicine, you learned the healing properties of various herbs. You're adept at collecting the right natural cures in all sorts of environments and preparing them properly. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Herbalism Lore skill. You gain the Natural Medicine skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Herbalism Lore"
+            ],
+            "featsGained": [
+                "Natural Medicine"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hermit",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=21",
+            "prerequisites": "",
+            "description": "In an isolated place-like a cave, remote oasis, or secluded mansion-you lived a life of solitude. Adventuring might represent your first foray out among other people in some time. This might be a welcome reprieve from solitude or an unwanted change, but in either case, you're likely still rough around the edges. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in your choice of either the Nature or Occultism skill, as well as a Lore skill related to the terrain you lived in as a hermit (such as Cave Lore or Desert Lore). You gain the Dubious Knowledge skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Occultism",
+                "Lore"
+            ],
+            "featsGained": [
+                "Dubious Knowledge"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hookclaw Digger",
+            "source": "Little Trouble in Big Absalom pg. 0",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=208",
+            "prerequisites": "Prerequisites Kobold ancestry",
+            "description": "You are a digger from the Hookclaw kobold tribe, born beneath the streets of Absalom, with muscles and mind hardened by years spent tunneling through rock and earth and a confidence built upon your pride in your draconic heritage. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost.  You're trained in the Crafting skill, the Mining Lore skill, and the Engineering Lore skill. You gain the Improvise Tool skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Mining Lore",
+                "Engineering Lore"
+            ],
+            "featsGained": [
+                "Improvise Tool"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hunter",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=22",
+            "prerequisites": "",
+            "description": "You stalked and took down animals and other creatures of the wild. Skinning animals, harvesting their flesh, and cooking them were also part of your training, all of which can give you useful resources while you adventure. Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Tanning Lore skill. You gain the Survey Wildlife skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Tanning Lore"
+            ],
+            "featsGained": [
+                "Survey Wildlife"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Insurgent",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=171",
+            "prerequisites": "",
+            "description": "You were more than a rebel; you were a revolutionary, fighting for the promise of a new or better country. You may or may not still believe in the cause, or perhaps victory or exile has led you on this new journey to trumpet your glory... or to escape the consequences of your defeat. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Deception skill, and the Warfare Lore skill. You gain the Lengthy Diversion skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Lengthy Diversion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Laborer",
+            "source": "Core Rulebook pg. 62",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=23",
+            "prerequisites": "",
+            "description": "You've spent years performing arduous physical labor. It was a difficult life, but you somehow survived. You may have embraced adventuring as an easier method to make your way in the world, or you might adventure under someone else's command. Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost. You're trained in the Athletics skill, and the Labor Lore skill. You gain the Hefty Hauler skill feat in Athletics.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Labor Lore",
+                "Athletics"
+            ],
+            "featsGained": [
+                "Hefty Hauler"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Martial Disciple",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=24",
+            "prerequisites": "",
+            "description": "You dedicated yourself to intense training and rigorous study to become a great warrior. The school you attended might have been a traditionalist monastery, an elite military academy, or the local branch of a prestigious mercenary organization. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in your choice of either the Acrobatics or Athletics skill, as well as the Warfare Lore skill. You gain a skill feat: Cat Fall if you chose Acrobatics or Quick Jump if you chose Athletics.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Athletics",
+                "Warfare Lore",
+                "Acrobatics",
+                "Athletics"
+            ],
+            "featsGained": [
+                "Cat Fall",
+                "Quick Jump"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Merchant",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=25",
+            "prerequisites": "",
+            "description": "In a dusty shop, market stall, or merchant caravan, you bartered wares for coin and trade goods. The skills you picked up still apply in the adventuring life, in which a good deal on a suit of armor could prevent your death. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Mercantile Lore skill. You gain the Bargain Hunter skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Bargain Hunter"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Miner",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=26",
+            "prerequisites": "",
+            "description": "You earned a living wrenching precious minerals from the lightless depths of the earth. Adventuring might have seemed lucrative or glamorous compared to this backbreaking labor- and if you have to head back underground, this time you plan to do so armed with a real weapon instead of a miner's pick. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Mining Lore skill. You gain the Terrain Expertise skill feat with underground terrain.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Mining Lore"
+            ],
+            "featsGained": [
+                "Terrain Expertise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Noble",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=27",
+            "prerequisites": "",
+            "description": "To the common folk, the life of a noble seems one of idyllic luxury, but growing up as a noble or member of the aspiring gentry, you know the reality: a noble's lot is obligation and intrigue. Whether you seek to escape your duties by adventuring or to better your station, you have traded silks and pageantry for an adventurer's life. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Genealogy Lore skill or Heraldry Lore skill. You gain the Courtly Graces skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Genealogy Lore"
+            ],
+            "featsGained": [
+                "Courtly Graces"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Nomad",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=28",
+            "prerequisites": "",
+            "description": "Traveling far and wide, you picked up basic tactics for surviving on the road and in unknown lands, getting by with few supplies and even fewer comforts. As an adventurer, you travel still, often into even more dangerous places. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and a Lore skill related to one terrain you traveled in (such as Desert Lore or Swamp Lore). You gain the Assurance skill feat with Survival.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Lore",
+                "Survival"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Outrider",
+            "source": "Advanced Player's Guide pg. 48",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=172",
+            "prerequisites": "",
+            "description": "In your youth, you galloped on horseback over vast prairies, serving as a vanguard for your settlement, an army, or another group. Seeing so many different lands built a thirst in you to adventure and explore the world instead of just racing past it. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Plains Lore skill. You gain the Express Rider skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Plains Lore"
+            ],
+            "featsGained": [
+                "Express Rider"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Pathfinder Recruiter",
+            "source": "Pathfinder Society Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=203",
+            "prerequisites": "",
+            "description": "The Pathfinder Society's always on the lookout for talent, but that talent rarely just stumbles into the Grand Lodge. Whether you're professionally trained to encourage new recruits or the Society's own scouts identified your potential and raised you from childhood, you're committed to expanding the Society's roster. Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and a Lore skill related to one city you've visited often. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Pilgrim",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=173",
+            "prerequisites": "",
+            "description": "In your youth, you made several pilgrimages to important shrines and holy sites. You might have been a mendicant friar, a seller of holy relics (real or fraudulent), or just a simple farmer following the dictates of your faith. Whatever the aims of your wanderings now, your faith still protects you on the road. Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Religion skill, and a Lore skill for your patron deity. You gain the Pilgrim's Token skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Lore"
+            ],
+            "featsGained": [
+                "Pilgrim's Token"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Prisoner",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=29",
+            "prerequisites": "",
+            "description": "You might have been imprisoned for crimes (whether you were guilty or not), or enslaved for some part of your upbringing. In your adventuring life, you take full advantage of your newfound freedom. Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost. You're trained in the Stealth skill, and the Underworld Lore skill. You gain the Experienced Smuggler skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Experienced Smuggler"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Raised by Belief",
+            "source": "Gods & Magic pg. 9",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=132",
+            "prerequisites": "",
+            "description": "Whether in a monastery, a religious household, or just as part of your everyday life, your upbringing was steeped in the traditions of a faith or philosophy. You might remain committed or you may have turned from your childhood creed, but your skills are still founded in your devotion.  Choose two ability boosts. One boost must be to an ability specified in the Divine Ability entry for your deity, and one is a free ability boost.  You're trained in your deity's associated skill, and you gain Assurance with that skill. You gain a Lore skill with a subcategory associated with your deity (Abadar Lore, for instance).",
+            "abilityBoosts": [],
+            "skillsTrained": [
+                "Lore"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Refugee",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=174",
+            "prerequisites": "",
+            "description": "You come from a land very distant from the one you now find yourself in, driven by war, plague, or simply in the pursuit of opportunity. Regardless of your origin or the reason you left your home, you find yourself an outsider in this new land. Adventuring is a way to support yourself while offering hope to those who need it most. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Society skill, and a Lore skill related to the settlement you came from. You gain the Streetwise skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Lore"
+            ],
+            "featsGained": [
+                "Streetwise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Returned",
+            "source": "Advanced Player's Guide pg. 51",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=188",
+            "prerequisites": "",
+            "description": "You died and miraculously returned with knowledge of the realms beyond death and a stronger link to life. Some dead and undead souls might feel a strange, instinctual kinship with you.  Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost.  You gain the Diehard feat and the Additional Lore feat for Boneyard Lore.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Boneyard Lore"
+            ],
+            "featsGained": [
+                "Diehard",
+                "Additional Lore"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Root Worker",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=175",
+            "prerequisites": "",
+            "description": "Some ailments can't be cured by herbs alone. You learned ritual remedies as well, calling on nature spirits to soothe aches and ward off the evil eye. Taking up with adventurers has given you company on the road, as well as protection from those who would brand you a fake-or worse. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Occultism skill, and the Herbalism Lore skill. You gain the Root Magic skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Herbalism Lore"
+            ],
+            "featsGained": [
+                "Root Magic"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Royalty",
+            "source": "Advanced Player's Guide pg. 51",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=189",
+            "prerequisites": "",
+            "description": "You are a prominent member of a royal family. You have taken up the life of an adventurer-perhaps you're a deposed queen hoping to regain her throne, a prince seeking a more exciting life, or a princess on a secret mission.  Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost.  You are trained in Society. You gain the Courtly Graces skill feat and can influence commoners in your family's territory, as well as nobility anywhere. If you later gain the Connections skill feat, you automatically have common and noble connections within any community in your royal family's territory and have noble connections in large communities outside your territory.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society"
+            ],
+            "featsGained": [
+                "Courtly Graces",
+                "Connections"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sailor",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=30",
+            "prerequisites": "",
+            "description": "You heard the call of the sea from a young age. Perhaps you signed onto a merchant's vessel, joined the navy, or even fell in with a crew of pirates and scalawags. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Athletics skill, and the Sailing Lore skill. You gain the Underwater Marauder skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Underwater Marauder"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Scavenger",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=176",
+            "prerequisites": "",
+            "description": "You've made a living sorting through the things society throws away. You might have scavenged simply to survive, or plied a trade as a ragpicker, dung carter, or the like. While you've left that life behind, you still keep one eye on the ground out of habit. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and a Lore skill for the settlement you grew up scavenging in. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Scholar",
+            "source": "Core Rulebook pg. 63",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=36",
+            "prerequisites": "",
+            "description": "You have a knack for learning, and sequestered yourself from the outside world to learn all you could. You read about so many wondrous places and things in your books, and always dreamed about one day seeing the real things. Eventually, that curiosity led you to leave your studies and become an adventurer. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in your choice of the Arcana, Nature, Occultism, or Religion skill, and the Academia Lore skill. You gain the Assurance skill feat in your chosen skill.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Nature",
+                "Occultism",
+                "Religion",
+                "Academia Lore"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Scout",
+            "source": "Core Rulebook pg. 64",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=32",
+            "prerequisites": "",
+            "description": "You called the wilderness home as you found trails and guided travelers. Your wanderlust could have called you to the adventuring life, or perhaps you served as a scout for soldiers and found you liked battle. Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and a Lore skill related to one terrain you scouted in (such as Forest Lore or Cavern Lore). You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Servant",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=177",
+            "prerequisites": "",
+            "description": "You held a role of servitude, waiting on nobles and engendering their trust as one of the confidantes of the household. You might have walked away on good terms, or perhaps you know dangerous secrets about your former masters. Regardless, you're adventuring for a change and finding that in this new role, the skills you've learned now serve you. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Labor Lore skill. You gain the Read Lips skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Labor Lore"
+            ],
+            "featsGained": [
+                "Read Lips"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sewer Dragon",
+            "source": "Pathfinder Society Quest #10: The Broken Scales pg. 16",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=207",
+            "prerequisites": "Prerequisites Kobold ancestry",
+            "description": "You are one of the Sewer Dragons, born in Absalom's sewers, strengthened by a life defending your territory.\r\nChoose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Kobold Lore skill. You gain the Snare Crafting skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Kobold Lore"
+            ],
+            "featsGained": [
+                "Snare Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Spell Seeker",
+            "source": "Pathfinder Society Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=204",
+            "prerequisites": "",
+            "description": "Conventional magic can only hold your attention for so long. Instead, you've devoted yourself to understanding truly esoteric spells, which invariably draws you to explore the world and all its eldritch traditions. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in your choice of either the Arcana or Occultism skill, as well as the Library Lore skill. You gain the Recognize Spell skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Occultism",
+                "Library Lore"
+            ],
+            "featsGained": [
+                "Recognize Spell"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Squire",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=178",
+            "prerequisites": "",
+            "description": "You trained at the feet of a knight, maintaining their gear and supporting them at tourneys and in battle. Now you search for a challenge that will prove you worthy of full knighthood, or you've spurned pomp and ceremony to test yourself in honest, albeit less formal, combat.  Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost.  You're trained in the Athletics skill and your choice of the Heraldry Lore or Warfare Lore skill. You gain the Armor Assist skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Heraldry Lore"
+            ],
+            "featsGained": [
+                "Armor Assist"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Street Urchin",
+            "source": "Core Rulebook pg. 64",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=33",
+            "prerequisites": "",
+            "description": "You eked out a living by picking pockets on the streets of a major city, never knowing where you'd find your next meal. While some folk adventure for the glory, you do so to survive. Choose two ability boosts. One must be to Dexterity or Constitution, and one is a free ability boost. You're trained in the Thievery skill, and a Lore skill for the city you lived in as a street urchin (such as Absalom Lore or Magnimar Lore). You gain the Pickpocket skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Thievery",
+                "Lore"
+            ],
+            "featsGained": [
+                "Pickpocket"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Tax Collector",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=179",
+            "prerequisites": "",
+            "description": "Reviled but required, you were sent when taxes were due. Performing your job might have required travel and persuasion, or perhaps you were responsible for collecting taxes on trade. Either way, it sometimes meant dirty hands, and adventuring seemed the next logical step to you. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and a Lore skill for the settlement that employed you. You gain the Quick Coercion skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Lore"
+            ],
+            "featsGained": [
+                "Quick Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Teacher",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=180",
+            "prerequisites": "",
+            "description": "You are incredibly knowledgeable, skilled, and perhaps even trained to teach children and adults about the world and its wonders. From books to classes, you're committed to imparting knowledge to all. Not everything can be taught or learned from a book, though, so you've become an adventurer to learn subjects more directly and bring that wisdom back to your students. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in your choice of either the Performance or Society skill, as well as the Academia Lore skill. You gain the Experienced Professional skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Society",
+                "Academia Lore"
+            ],
+            "featsGained": [
+                "Experienced Professional"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Tinker",
+            "source": "Core Rulebook pg. 64",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=34",
+            "prerequisites": "",
+            "description": "Creating all sorts of minor inventions scratches your itch for problem-solving. Your engineering skills take a particularly creative bent, and no one know what you'll come up with next. It might be a genius device with tremendous potential... or it might explode. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Engineering Lore skill. You gain the Specialty Crafting skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Engineering Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Trailblazer",
+            "source": "Pathfinder Society Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=205",
+            "prerequisites": "",
+            "description": "Uncharted realms have always intrigued you, and you've explored and mapped large territories in service to merchants, governments, or your own curiosity. Where some see a blank spot on a map, you see the potential for something new and undiscovered. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Cartography Lore skill. You gain the Terrain Expertise skill feat with one terrain you've explored (such as forest or underground).",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Cartography Lore"
+            ],
+            "featsGained": [
+                "Terrain Expertise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Translator",
+            "source": "Pathfinder Society Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=206",
+            "prerequisites": "",
+            "description": "In your youth, you learned to transcribe books and translate scrolls to preserve knowledge or perhaps to aid wealthy merchants and politicians. Whether you set out to make your own fortune or are drawn to decipher the strangest codes, your linguistic training will guide your discoveries. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Scribing Lore skill. You gain the Multilingual skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Scribing Lore"
+            ],
+            "featsGained": [
+                "Multilingual"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Ward",
+            "source": "Advanced Player's Guide pg. 49",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=181",
+            "prerequisites": "",
+            "description": "When you were young, you became the ward of another house-boarded, fed, and educated, but never quite a part of the family. Perhaps you had to tend to their needs in return for feeding and raising you, or perhaps you were provided for but disregarded. Now, adventuring is your chance to grow and roam free. Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Genealogy Lore skill. You gain the Fascinating Performance skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Genealogy Lore"
+            ],
+            "featsGained": [
+                "Fascinating Performance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Warrior",
+            "source": "Core Rulebook pg. 64",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=35",
+            "prerequisites": "",
+            "description": "In your younger days, you waded into battle as a mercenary, a warrior defending a nomadic people, or a member of a militia or army. You might have wanted to break out from the regimented structure of these forces, or you could have always been as independent a warrior as you are now. Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost. You're trained in the Intimidation skill, and the Warfare Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Legacy": [
+        {
+            "name": "Aiudara Seeker",
+            "source": "Pathfinder #150: Broken Promises pg. 73",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=127",
+            "prerequisites": "",
+            "description": "The aiudara of Alseta's Ring have become more well known, and you are interested in learning more about them. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Arcana skill, and the Portal Lore skill. You gain the Quick Identification skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Portal Lore"
+            ],
+            "featsGained": [
+                "Quick Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hermean Heritor",
+            "source": "Pathfinder #150: Broken Promises pg. 73",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=128",
+            "prerequisites": "",
+            "description": "With the restrictions on Hermean citizenship lifted, you may have fled the city of Promise or have spent some of your childhood in the company of someone who did. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Society skill, and the Legal Lore skill. You gain the Multilingual skill feat or the Assurance skill feat for Society.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Legal Lore"
+            ],
+            "featsGained": [
+                "Multilingual",
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Legendary Parents",
+            "source": "Pathfinder #150: Broken Promises pg. 73",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=129",
+            "prerequisites": "",
+            "description": "One or more of your parents (either biological or adoptive) were heroes of the Age of Ashes Adventure Path. Others tend to treat you with a bit more respect, or perhaps fear your connections to people of great power. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Genealogy Lore skill. You gain the Group Coercion skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Genealogy Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Touched by Dahak",
+            "source": "Pathfinder #150: Broken Promises pg. 73",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=131",
+            "prerequisites": "",
+            "description": "As the manifestation of Dahak was destroyed, a shard of the dragon god's wrathful nature infused you, resulting in a violent temper, strange apocalyptic dreams, an obsession with dragon hunting, or some other touch of his influence. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Athletics skill, and the Dragon Lore skill. You gain the Titan Wrestler skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Dragon Lore"
+            ],
+            "featsGained": [
+                "Titan Wrestler"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Regional": [
+        {
+            "name": "Child of the Puddles",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=54",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "You grew up in the soggy, squalid quarter of Absalom known as the Puddles. You're at home in tightly packed urban environments.Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Acrobatics skill, and the Absalom Lore skill. You gain the Steady Balance skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Absalom Lore"
+            ],
+            "featsGained": [
+                "Steady Balance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Diobel Pearl Diver",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=58",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "You spent a portion of your youth diving and gathering precious pearls under the attentive eyes of Kortos Consortium merchants.Choose two ability boosts. One must be to Constitution or Dexterity, and one is a free ability boost. You're trained in the Athletics skill, and the Ocean Lore skill. You gain the Underwater Marauder skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Ocean Lore"
+            ],
+            "featsGained": [
+                "Underwater Marauder"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Freed Slave of Absalom",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=55",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "As a recently freed slave in Absalom, you belong to a new, close-knit social class at the heart of the city's most important trades.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Absalom Lore skill. You gain the Streetwise skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Absalom Lore"
+            ],
+            "featsGained": [
+                "Streetwise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Grand Council Bureaucrat",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=53",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "You spent years working as a clerk to a functionary in Absalom's government. Your service taught you a thing or two about rousing speeches and manipulating the city's bureaucracy.Choose two ability boosts. One must be to Charisma or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Government Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Charisma",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Government Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Inlander",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=56",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "You grew up in an untamed region of the Isle of Kortos, and you know how to survive in the wild.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and a Lore skill  related to the terrain type associated with your home region (such as Hills Lore or Mountains Lore) You gain the Survey Wildlife skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Lore"
+            ],
+            "featsGained": [
+                "Survey Wildlife"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Menagerie Dung Sweeper",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=57",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "Whether you washed warrior beasts below the Irorium's arena floor or tended to the mutated animals of a Puddle sideshow, you are experienced with all manner of weird wildlife.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Animal Lore skill. You gain the Train Animal skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Animal Lore"
+            ],
+            "featsGained": [
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Pathfinder Hopeful",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=51",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "You've long wanted to join the adventurous Pathfinder Society. You have taken up the dangerous life of an adventurer in hopes of earning a spot among the Pathfinders.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Pathfinder Society Lore skill. You gain the Additional Lore skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Pathfinder Society Lore"
+            ],
+            "featsGained": [
+                "Additional Lore"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Trade Consortium Underling",
+            "source": "World Guide pg. 22",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=52",
+            "prerequisites": "Region Absalom and Starstone Isle",
+            "description": "Your experience as a ledger-keeper for one of Absalom's trade guilds has made you a canny investor and shrewd entrepreneur.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Society skill, and the Business Lore skill. You gain the Experienced Professional skill feat.Broken Lands",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Business Lore"
+            ],
+            "featsGained": [
+                "Experienced Professional"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Aspiring River Monarch",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=59",
+            "prerequisites": "Region Broken Lands",
+            "description": "New realms rise constantly in the River Kingdoms, and you intend to lead one of them. Making your reign last, however, will require both strength and grace.Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Politics Lore skill. You gain the Courtly Graces skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Courtly Graces"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Issian Partisan",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=64",
+            "prerequisites": "Region Broken Lands",
+            "description": "You grew up among the northern houses of Brevoy in old Issia. Steeped in the cultural legacy of pirates and smugglers, you rely on your cleverness and charm as you make your way throughout the world.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Deception skill, and the Underworld Lore skill. You gain the Charming Liar skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Charming Liar"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Razmiran Faithful",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=60",
+            "prerequisites": "Region Broken Lands",
+            "description": "You serve a living god who rules upon the face of Golarion, and this gives your actions a divine mandate not to be trifled with.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Razmir Lore skill. You gain the Group Coercion skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Razmir Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Rostland Partisan",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=62",
+            "prerequisites": "Region Broken Lands",
+            "description": "You grew up among the southern houses of Brevoy in old Rostland. You're accustomed to arguing from a position of underappreciated worth.Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Politics Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sarkorian Reclaimer",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=61",
+            "prerequisites": "Region Broken Lands",
+            "description": "Whether you trace your heritage to lost Sarkoris or are a crusader trying to atone for past fanatics' wrongs, you seek to liberate the Sarkorian homeland from the demons who have defiled it.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Medicine skill, and the Abyssal Lore skill. You gain the Battle Medicine skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Abyssal Lore"
+            ],
+            "featsGained": [
+                "Battle Medicine"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sarkorian Survivor",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=73",
+            "prerequisites": "Region Broken Lands",
+            "description": "he devastation and carnage of the Worldwound were nearly complete, but you somehow managed to survive it.Choose two ability boosts. One must be to Constitution or Strength, and one is a free ability boost. You're trained in the Survival skill, and the Sarkorian History Lore skill. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Strength"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Sarkorian History Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Wonder Taster",
+            "source": "World Guide pg. 34",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=63",
+            "prerequisites": "Region Broken Lands",
+            "description": "Having once sampled Numerian fluids, you've tasted knowledge beyond comprehension. You are driven to recapture that astounding experience.Choose two ability boosts. One must be to Intelligence or Constitution, and one is a free ability boost. You're trained in the Crafting skill, and the Alchemical Lore skill. You gain the Alchemical Crafting skill feat.Eye of Dread",
+            "abilityBoosts": [
+                "Intelligence",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Alchemical Lore"
+            ],
+            "featsGained": [
+                "Alchemical Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Belkzen Slayer",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=65",
+            "prerequisites": "Region Eye of Dread",
+            "description": "You are a fearsome warrior from the Hold of Belkzen, and your clan counts on you for support, counsel, and defense. With the rising threat of the Whispering Tyrant threatening the safety of your home, you must not let your people down.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Orc Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Orc Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Cursed Family",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=70",
+            "prerequisites": "Region Eye of Dread",
+            "description": "Rumors abound that your family is cursed. While that would explain several unfortunate events in your family history, you may or may not believe it. Regardless, odd coincidences plague your lineage, and perhaps even appear in your own life, and you have become used to spotting strangeness around you.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Occultism skill, and the Curse Lore skill. You gain the Oddity Identification skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Curse Lore"
+            ],
+            "featsGained": [
+                "Oddity Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Lastwall Survivor",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=68",
+            "prerequisites": "Region Eye of Dread",
+            "description": "You managed to escape the devastation that the Whispering Tyrant brought to your nation, but you lost everything to the lich-king's minions, including your home and many friends and family.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Medicine skill, and the Undead Lore skill. You gain the Battle Medicine skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Undead Lore"
+            ],
+            "featsGained": [
+                "Battle Medicine"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Molthuni Mercenary",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=69",
+            "prerequisites": "Region Eye of Dread",
+            "description": "Whether you sought citizenship or simply needed a steady paycheck, you spent some of your time as a paid mercenary in the armed forces of Molthune, where you fought against Molthune's enemies such as Nirmathas or the Ironfang Legion. Alternatively, you might have worked at sea, protecting Molthune's military and trading ships against pirates on Lake Encarthan.Choose two ability boosts. One must be to Constitution or Strength, and one is a free ability boost. You're trained in the Athletics skill, and the Mercenary Lore skill. You gain the Experienced Professional skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Strength"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Mercenary Lore"
+            ],
+            "featsGained": [
+                "Experienced Professional"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Nirmathi Guerrilla",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=66",
+            "prerequisites": "Region Eye of Dread",
+            "description": "Woodcraft comes naturally to you, and you have learned how to use the forest to your tactical advantage against superior forces in skirmishes against the Molthuni army or the Ironfang Legion.Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Forest Lore skill. You gain the Terrain Stalker (underbrush) skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Forest Lore"
+            ],
+            "featsGained": [
+                "Terrain Stalker"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Onyx Trader",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=67",
+            "prerequisites": "Region Eye of Dread",
+            "description": "Oprak doesn't share the secrets of the Onyx Vault with many, but you are one of the lucky few to be permitted into the heart of the nation. You have traveled the extradimensional paths of the Stone Roads and traded goods across a wide variety of lands. You've learned to step lively in foreign markets of all types.Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Mercantile Lore skill. You gain the Multilingual skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Multilingual"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Ustalavic Academic",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=71",
+            "prerequisites": "Region Eye of Dread",
+            "description": "You were educated at a famed Ustalavic academy, such as the University of Lepidstadt or the Sincomakti School of Sciences, and received quality instruction in advanced concepts of mathematics, science, and engineering.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Crafting skill, and the Academia Lore skill. You gain the Skill Training skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Academia Lore"
+            ],
+            "featsGained": [
+                "Skill Training"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Whispering Way Scion",
+            "source": "World Guide pg. 46",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=72",
+            "prerequisites": "Region Eye of Dread",
+            "description": "Your  family  has  long  been associated with the enigmatic death cult known as the Whispering Way, which was recently responsible for the terrible devastation in the nation of Lastwall. Whether or not you have followed in their footsteps, you know many of the philosophy's secrets.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Religion skill, and the Undead Lore skill. You gain the Student of the Canon skill feat.Golden Road",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Undead Lore"
+            ],
+            "featsGained": [
+                "Student of the Canon"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Black Market Smuggler",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=74",
+            "prerequisites": "Region Golden Road",
+            "description": "You know how to work the less-than-legal side of the region's markets and know how to slip contraband past the authorities.Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Stealth skill, and the Underworld Lore skill. You gain the Experienced Smuggler skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Experienced Smuggler"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Desert Tracker",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=75",
+            "prerequisites": "Region Golden Road",
+            "description": "You're at home blazing trails in the burning sands, and you made a living guiding or following creatures in the desert. You might be a native nomad, an experienced desert guide, a naturalist, a bandit driven into the dunes by the law-or all of the above.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Desert Lore skill. You gain the Experienced Tracker skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Desert Lore"
+            ],
+            "featsGained": [
+                "Experienced Tracker"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Merabite Prodigy",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=76",
+            "prerequisites": "Region Golden Road",
+            "description": "Even in a city renowned for its alchemy, you were able to rise above the competition.Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Alchemical Lore skill. You gain the Specialty Crafting skill feat with alchemy.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Alchemical Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Osirionologist",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=77",
+            "prerequisites": "Region Golden Road",
+            "description": "Whether you're a fascinated outsider or a local proud of your nation's storied past, you're a devoted student of Osirion's history. You might be a traveling professor, a member of a society like the Pathfinders or the Esoteric Order of the Palatine Eye, or even a simple tomb robber cashing in on the glories of the past.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Occultism skill, and the Ancient Osirion Lore skill. You gain the Oddity Identification skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Ancient Osirion Lore"
+            ],
+            "featsGained": [
+                "Oddity Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Purveyor of the Bizarre",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=78",
+            "prerequisites": "Region Golden Road",
+            "description": "Whether in Katapesh or one of the bustling markets along the Path of Salt, you've spent enough time buying and selling ancient or unusual items to give you an instinctive ability to quickly sort valuable trinkets from worthless baubles.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Arcana skill, and the Mercantile Lore skill. You gain the Quick Identification skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Quick Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Secular Medic",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=79",
+            "prerequisites": "Region Golden Road",
+            "description": "You're from Rahadoum, where the Laws of Mortality taught you to reject the gods, yet you've seen firsthand how dangerous it can be to go without healing magic. As a result, you've thrown yourself into the study of medicine, so you can save lives without saving souls.Choose two ability boosts. One must be to Wisdom or Dexterity, and one is a free ability boost. You're trained in the Medicine skill, and the Anatomy Lore skill. You gain the Battle Medicine skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Anatomy Lore"
+            ],
+            "featsGained": [
+                "Battle Medicine"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Thuvian Unifier",
+            "source": "World Guide pg. 58",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=80",
+            "prerequisites": "Region Golden Road",
+            "description": "You believe the city-states of Thuvia should be united into one nation under the rule of your home city (most commonly Aspenthar), and you're willing to do whatever it takes to make it happen.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Politics Lore skill. You gain the Quick Coercion skill feat.High Seas",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Quick Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Aspiring Free Captain",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=81",
+            "prerequisites": "Region High Seas",
+            "description": "You seek to join the Free Captains of the Shackles and have\r\nlearned everything you need to know about sailing and bossing\r\npeople around. Now you just need a crew and a ship.Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Sailing Lore skill. You gain the Group Coercion skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hermean Expatriate",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=82",
+            "prerequisites": "Region High Seas",
+            "description": "You have been exiled from Hermea, perhaps of your own accord\r\nor perhaps because you didn't\r\nmeasure up. However, you take\r\nwith you some of the benefits\r\nof the excellent education\r\nafforded to its citizenry.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Dragon Lore skill. You gain the Skill Training skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Dragon Lore"
+            ],
+            "featsGained": [
+                "Skill Training"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Mantis Scion",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=83",
+            "prerequisites": "Region High Seas",
+            "description": "At least one of your parents is a member of the notorious Red\r\nMantis assassins, merciless killers for hire who rarely fail to\r\nclaim their marks. Whether on purpose or by simple exposure,\r\nyou were trained from a young age in the art of stalking and\r\nkilling people.Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Stealth skill, and the Assassin Lore skill. You gain the Assurance skill feat with Stealth.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Assassin Lore",
+                "Stealth."
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Press-Ganged",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=84",
+            "prerequisites": "Region High Seas",
+            "description": "You were forced into service as a sailor against your will.\r\nPerhaps you were punished for a crime, were drafted into\r\nmilitary service, are repaying a debt, or simply were abducted.\r\nThough you were initially trained as a simple deckhand, you\r\nmay have subsequently studied a trade under one of the\r\nvessel's specialists.Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Society skill, and the Sailing Lore skill. You gain the Experienced Professional skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Experienced Professional"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Scholar of the Ancients",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=85",
+            "prerequisites": "Region High Seas",
+            "description": "You're fascinated by the lost Azlanti Empire and have dedicated\r\nyourself to seeking out and studying every broken artifact or\r\nscrap of knowledge that remains, whether as an academic pursuit\r\nor simply for the joy of treasure hunting.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Arcana skill, and the Azlant Lore skill. You gain the Quick Identification skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Azlant Lore"
+            ],
+            "featsGained": [
+                "Quick Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Storm Survivor",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=86",
+            "prerequisites": "Region High Seas",
+            "description": "Through luck or through skill, you managed to survive a\r\ncatastrophic maritime disaster, such as a shipwreck or being\r\nthrown overboard. You have a keen sense for weather or\r\nsituations that are similar to the one you escaped.Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Weather Lore skill. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Weather Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Undersea Enthusiast",
+            "source": "World Guide pg. 70",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=87",
+            "prerequisites": "Region High Seas",
+            "description": "You love diving and exploring the world beneath the waves,\r\nand long periods of swimming have trained you to move easily\r\nthrough the water. You're also fascinated by undersea creatures\r\nand cultures-and may even have a trace of one of them in your\r\nown lineage.Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost. You're trained in the Athletics skill, and the Ocean Lore skill. You gain the Underwater Marauder skill feat.Impossible Lands",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Ocean Lore"
+            ],
+            "featsGained": [
+                "Underwater Marauder"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Alkenstar Tinker",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=88",
+            "prerequisites": "Region Impossible Lands",
+            "description": "Your dedication to the scientific inquiry of your native Alkenstar provides great insight into mechanical and chemical innovation.Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Engineering Lore skill. You gain the Alchemical Crafting skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Engineering Lore"
+            ],
+            "featsGained": [
+                "Alchemical Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Geb Crusader",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=89",
+            "prerequisites": "Region Impossible Lands",
+            "description": "You grew up considering the existence of the undead nation of Geb an atrocity and trained to one day take part in destroying it and putting its vile inhabitants to their final rest. Key to your preparations is a thorough study of Pharasma, Urgathoa, and other undead-related deities and their philosophies.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Religion skill, and the Undead Lore skill. You gain the Student of the Canon skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Undead Lore"
+            ],
+            "featsGained": [
+                "Student of the Canon"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Mana Wastes Refugee",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=90",
+            "prerequisites": "Region Impossible Lands",
+            "description": "Exposure to the corrupting influence of the Mana Wastes' strange energies has warped your inner essence, resulting in unpredictable interactions with magic items and more than a little know-how about surviving under bizarre and adverse natural conditions.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Arcana skill, and the Wilderness Lore skill. You gain the Trick Magic Item skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Wilderness Lore"
+            ],
+            "featsGained": [
+                "Trick Magic Item"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Nexian Mystic",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=91",
+            "prerequisites": "Region Impossible Lands",
+            "description": "Your initiations into the Nexian mysteries and the philosophies of the Arclords of Nex grant you a preternatural comprehension of the arcane underpinnings of existence.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Arcana skill, and a Lore skill related to one plane of your choice (other than the material plane). You gain the Arcane Sense skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Lore"
+            ],
+            "featsGained": [
+                "Arcane Sense"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Oenopion Ooze-Tender",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=92",
+            "prerequisites": "Region Impossible Lands",
+            "description": "Your apprenticeship in one of Oenopion's unorthodox arcane and alchemical academies instilled in you a deep reservoir of mostly reliable esoteric knowledge, not to mention a deep resentment born of countless hours spent mucking ooze pens and feeding helpless creatures to ravenous, belching jellies and gelatinous puddings.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Ooze Lore skill. You gain the Dubious Knowledge skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Ooze Lore"
+            ],
+            "featsGained": [
+                "Dubious Knowledge"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Perfection Seeker",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=93",
+            "prerequisites": "Region Impossible Lands",
+            "description": "You aspire to perfect your body and mind in the tradition of Jalmeray's Houses of Perfection, honing your acrobatic skills and mental faculties in preparation for a lifetime pushing the edge of what most consider possible.Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Acrobatics skill, and the Warfare Lore skill. You gain the Cat Fall skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Cat Fall"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Quick",
+            "source": "World Guide pg. 82",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=94",
+            "prerequisites": "Region Impossible Lands",
+            "description": "Staying alive among the scheming, ravenous undead of Geb required a deep knowledge of their motivations, capabilities, and weaknesses. More often than not, it also required the ability to weave alibis and life-preserving half-truths capable of swaying a stilled heart.Choose two ability boosts. One must be to Charisma or Constitution, and one is a free ability boost. You're trained in the Deception skill, and the Undead Lore skill. You gain the Charming Liar skill feat.Mwangi Expanse",
+            "abilityBoosts": [
+                "Charisma",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Undead Lore"
+            ],
+            "featsGained": [
+                "Charming Liar"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bekyar Restorer",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=95",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "Though many Bekyars worship demons, you seek to pave a different path for yourself and your kindred, while also attempting to change other Mwangi's treatment of your culture.Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Abyss Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Abyss Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bonuwat Wavetouched",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=96",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You are a child of the Bonuwat people, and the sea's salt flows through your veins. You've taken to sailing and swimming gracefully and with ease, earning you the honorific 'wavetouched.'Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Athletics skill, and the Ocean Lore skill. You gain the Underwater Marauder skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Ocean Lore"
+            ],
+            "featsGained": [
+                "Underwater Marauder"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bright Lion",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=97",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You are a member of the Bright Lions and seek to overthrow the tyrannical reign of Walkena and free Mzali from his cruel whims. You're experienced operating undercover and have had to be cautious of what you say and who you trust, lest you fall afoul of the god-king's terrible punishments.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Deception skill, and the Mzali Lore skill. You gain the Lie to Me skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Mzali Lore"
+            ],
+            "featsGained": [
+                "Lie to Me"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Magaambya Academic",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=98",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You studied magic at the prestigious Magaambya academy in Nantambu, learning magical traditions dating back to Old-Mage Jatembe and earning a pedigree respected by magical scholars almost everywhere.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in your choice of either the Arcana or Nature skill, as well as the Academia Lore skill. You gain the Recognize Spell skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Nature",
+                "Academia Lore"
+            ],
+            "featsGained": [
+                "Recognize Spell"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Senghor Sailor",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=99",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "As an experienced sailor from Senghor, you know that the only thing saving you from disaster on the high seas is a properly maintained ship. You know boat-building inside and out and you can quickly cobble together a solution in the event that something breaks.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Crafting skill, and the Sailing Lore skill. You gain the Quick Repair skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Quick Repair"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Shory Seeker",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=100",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You've dedicated your life to unraveling the secrets of the ancient Shory Empire, either through meticulous research or by traveling into dangerous and distant ruins to track down long- lost artifacts.Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Shory Lore skill. You gain the Specialty Crafting skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Shory Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sodden Scavenger",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=101",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You've managed to eke out an existence in the storm-wracked Sodden Lands and have become an expert at scavenging food and tools.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Swamp Lore skill. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Swamp Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Vidrian Reformer",
+            "source": "World Guide pg. 94",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=102",
+            "prerequisites": "Region Mwangi Expanse",
+            "description": "You know that the only way your homeland of Vidrian can remain free from outside conquerors is by forging a strong and unified government. As such, you seek to bind your fellow citizens together through careful diplomacy and force of personality-or, if necessary, subterfuge and intrigue.Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Politics Lore skill. You gain the Hobnobber skill feat.Old Cheliax",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Atteran Rancher",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=103",
+            "prerequisites": "Region Old Cheliax",
+            "description": "You grew up breeding and training the famous horses of the Atteran Ranches in northern Nidal. You may even be sympathetic to the Desnan dissidents who hide there from the Umbral Court.Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Nature skill, and the Animal Lore skill. You gain the Train Animal skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Animal Lore"
+            ],
+            "featsGained": [
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Bellflower Agent",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=104",
+            "prerequisites": "Region Old Cheliax",
+            "description": "You joined a secret society dedicated to freeing halfling slaves, most likely from the cruelty of Chelish reign. You know how to smuggle people in and out of countries.Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Stealth skill, and the Underworld Lore skill. You gain the Experienced Smuggler skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Experienced Smuggler"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Chelish Rebel",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=105",
+            "prerequisites": "Region Old Cheliax",
+            "description": "You joined the fight against House Thrune. You may have helped liberate the nation of Ravounel, or you might be involved in another rebellion, such as Pezzack's, that studied Ravounel's successes.Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Kintargo Lore skill. You gain the Streetwise skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Kintargo Lore"
+            ],
+            "featsGained": [
+                "Streetwise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Child of Westcrown",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=106",
+            "prerequisites": "Region Old Cheliax",
+            "description": "Whether you come from Westcrown or elsewhere, you hold the values of pre-Thrune Cheliax dear. You disdain the infernal government, but you are proud of your country and do not consider yourself a rebel.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Diplomacy skill, and the Westcrown Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Westcrown Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Goblinblood Orphan",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=107",
+            "prerequisites": "Region Old Cheliax",
+            "description": "Your family, whether goblin, hobgoblin, or human, died in the Goblinblood Wars. Though you were marked by these losses, you managed to survive through your own resilience and resourcefulness.Choose two ability boosts. One must be to Dexterity or Constitution, and one is a free ability boost. You're trained in the Survival skill, and the Goblin Lore skill. You gain the Assurance skill feat with Survival.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Goblin Lore"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Shadow Haunted",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=108",
+            "prerequisites": "Region Old Cheliax",
+            "description": "You are from Nidal, and regardless of your personal values, Zon-Kuthon has a claim on your soul due to an ancient pact. The Midnight Lord's unsettling influence is bred deep into your bones.Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Intimidation skill, and the Shadow Plane Lore skill. You gain the Quick Coercion skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Shadow Plane Lore"
+            ],
+            "featsGained": [
+                "Quick Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Thrune Loyalist",
+            "source": "World Guide pg. 106",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=109",
+            "prerequisites": "Region Old Cheliax",
+            "description": "Despite the setbacks Cheliax has suffered recently, your loyalties lie with the devil-backed House Thrune. You consider the current queen to be the rightful ruler of your homeland, and you are willing to act against her enemies.Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Religion skill, and the Hell Lore skill. You gain the Student of the Canon skill feat.Saga Lands",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Hell Lore"
+            ],
+            "featsGained": [
+                "Student of the Canon"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Mammoth Speaker",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=110",
+            "prerequisites": "Region Saga Lands",
+            "description": "You have learned the secrets of taming the mighty mammoths and other megafauna of the far north. Perhaps these talents are a part of your people's traditional customs, or perhaps you sought out these massive animals of your own accord.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Animal Lore skill. You gain the Train Animal skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Animal Lore"
+            ],
+            "featsGained": [
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Shoanti Name-Bearer",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=111",
+            "prerequisites": "Region Saga Lands",
+            "description": "You are a member of a Shoanti quah and have gone through its coming of age ceremony, gaining the traditional tattoo of your quah and earning your adult name.Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Athletics skill, and the Quah Lore skill. You gain the Combat Climber skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Quah Lore"
+            ],
+            "featsGained": [
+                "Combat Climber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Thassilonian Traveler",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=112",
+            "prerequisites": "Region Saga Lands",
+            "description": "You come from ancient Thassilon, one of the citizens that appeared out of time alongside the city of Xin-Edasseril. You know many things that have been long forgotten... along with many things that are no longer correct.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Arcana skill, and the Thassilon Lore skill. You gain the Dubious Knowledge skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Thassilon Lore"
+            ],
+            "featsGained": [
+                "Dubious Knowledge"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Ulfen Raider",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=113",
+            "prerequisites": "Region Saga Lands",
+            "description": "You are an Ulfen warrior, feared among Avistan for the merciless and devastating raids your people once conducted along the shores. Though the days of these Ulfen raids are largely past, you have been trained to strike terror into the hearts of those who face you.Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Sailing Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Sailing Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Varisian Wanderer",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=114",
+            "prerequisites": "Region Saga Lands",
+            "description": "You have spent your youth wandering the lands of Varisia and beyond among the brightly painted wagons of a Varisian caravan. You have heard endless tales of your people's history and lore, and have learned many songs and stories from the disparate people you have met.Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Circus Lore skill. You gain the Fascinating Performance skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Circus Lore"
+            ],
+            "featsGained": [
+                "Fascinating Performance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Winter's Child",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=115",
+            "prerequisites": "Region Saga Lands",
+            "description": "Your or one of your ancestors hails from Irrisen, and some spark of the icy region's magic has manifested itself within your bones. The blood of Baba Yaga's legacy runs in your veins, and you are at one with the mysteries and dangers of the frozen\u00a0land.Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Arcana skill, and the Weather Lore skill. You gain the Arcane Sense skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Weather Lore"
+            ],
+            "featsGained": [
+                "Arcane Sense"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Witch Wary",
+            "source": "World Guide pg. 118",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=116",
+            "prerequisites": "Region Saga Lands",
+            "description": "You have little love or trust for spellcraft and those who practice it, and have developed a paranoid knack for recognizing such tricks. You are constantly on guard for the magic of witches and have been trained to spot the signs of those with minds affected by magic.Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Occultism skill, and the Curse Lore skill. You gain the Oddity Identification skill feat.Shining Kingdoms",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Curse Lore"
+            ],
+            "featsGained": [
+                "Oddity Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Final Blade Survivor",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=117",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You fell prey to the whims of the Galtan mob and were scheduled for execution by final blade, but through skill-or sheer luck-you managed to talk your way out of it. Choose two ability boosts. One must be to Charisma or Wisdom, and one is a free ability boost. You're trained in the Deception skill, and the Revolution Lore skill. You gain the Charming Liar skill feat.",
+            "abilityBoosts": [
+                "Charisma",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Revolution Lore"
+            ],
+            "featsGained": [
+                "Charming Liar"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Kalistrade Follower",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=118",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You follow the philosophy of the Prophecies of Kalistrade, seeking to build up your wealth in this life so that you might meet the next world on your own terms.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Diplomacy skill, and the Kalistrade Lore skill. You gain the Bargain Hunter skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Kalistrade Lore"
+            ],
+            "featsGained": [
+                "Bargain Hunter"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Kyonin Emissary",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=119",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You were trained to be an ambassador of the elven land of Kyonin, and you have now been sent out into the wider world to build alliances between Kyonin and the neighboring kingdoms.Choose two ability boosts. One must be to Charisma or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Politics Lore skill. You gain the Multilingual skill feat.",
+            "abilityBoosts": [
+                "Charisma",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Multilingual"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Lumber Consortium Laborer",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=120",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You have suffered as a worker for the unscrupulous Lumber Consortium, laboring under harsh conditions in dangerous wooded regions of Andoran.Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Athletics skill, and the Forest Lore skill. You gain the Assurance skill feat with Athletics.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Forest Lore",
+                "Athletics"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Rivethun Adherent",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=121",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You have spent time learning the practices and traditions of the ancient Rivethun dwarven shamans and can recognize all sorts of magic. You may have chosen your own road since then, or you may remain an adherent of the philosophy.Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Occultism skill, and the Spirit Lore skill. You gain the Recognize Spell skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Occultism",
+                "Spirit Lore"
+            ],
+            "featsGained": [
+                "Recognize Spell"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Taldan Schemer",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=122",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "Whether willing or unwilling, you have been involved in the many cutthroat political intrigues within Taldor. You might have been born into it as a member of the aristocracy, or you might have taken an active role in the recent events of the War for the Crown.Choose two ability boosts. One must be to Charisma or Constitution, and one is a free ability boost. You're trained in the Diplomacy skill, and the Politics Lore skill. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Charisma",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Wildwood Local",
+            "source": "World Guide pg. 130",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=123",
+            "prerequisites": "Region Shining Kingdoms",
+            "description": "You might have been born and raised among the druids of the Verduran Forest, or you may have spent time among them as an adult and come to know their ways.Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Forest Lore skill. You gain the Natural Medicine skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Forest Lore"
+            ],
+            "featsGained": [
+                "Natural Medicine"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "The Fall of Plaguestone": [
+        {
+            "name": "Lesser Scion",
+            "source": "The Fall of Plaguestone pg. 55",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=37",
+            "prerequisites": "",
+            "description": "You are the youngest child in a noble house (in Cheliax, Isger, or Andoran) and stand to inherit nothing from your family. Although you have a minor title, it affords you no lands or wealth, but it has garnered you a small amount of respect and deference in your travels. When play begins, you are riding in a caravan bound for Almas, where a cousin has promised to allow you to stay with them for a month. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Diplomacy skill, and the Heraldry Lore skill. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Heraldry Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Lost and Alone",
+            "source": "The Fall of Plaguestone pg. 55",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=38",
+            "prerequisites": "",
+            "description": "You were training to become a knight in Lastwall when the Whispering Tyrant escaped his imprisonment and destroyed the nation. It was only by dumb luck that you are alive at all, but the memories of that fateful day haunt your dreams. When play begins, you have boarded a caravan heading toward a new town, having worn out your welcome at the taverns and inns of Elidir. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Warfare Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Missionary",
+            "source": "The Fall of Plaguestone pg. 55",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=39",
+            "prerequisites": "",
+            "description": "You received training from clergy in a faraway temple, who sent you out into the world to spread the faith. Although you are relatively new at this, you are always on the lookout for new places in need of your deity's teachings and guidance. When play begins, you are riding along in a caravan making your way through sparsely populated regions of Isger, spreading the news of your faith to those who will listen. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Diplomacy skill, and the Scribing Lore skill. You gain the Group Impression skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Scribing Lore"
+            ],
+            "featsGained": [
+                "Group Impression"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Refugee (FoP)",
+            "source": "The Fall of Plaguestone pg. 55",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=40",
+            "prerequisites": "",
+            "description": "The fighting around the Lake Encarthan region has forced many of the people residing there to flee from the violence. Although your home is gone, you have managed to survive and are making your way south in search of a better life. When play begins, you are riding along in a caravan taking you to what might be either a new home in Andoran or simply another waypoint in your journey. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Survival skill, and the Hunting Lore skill. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Hunting Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Teamster",
+            "source": "The Fall of Plaguestone pg. 55",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=41",
+            "prerequisites": "",
+            "description": "You left your home a few months back for a life on the road, working for one caravan company and then another, always on the lookout for a new job and a better life. Last week, you were hired by the Bort Bargith's company in Elidir. You don't know anyone from the company just yet, but most of its members seem to be honest merchants and traders. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Nature skill, and the Mercantile Lore skill. You gain the Train Animal skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Age of Ashes": [
+        {
+            "name": "Dragon Scholar",
+            "source": "Age of Ashes Player's Guide pg. 4",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=42",
+            "prerequisites": "",
+            "description": "Dragons have fascinated you for as long as you can remember. The potent power they possess, the long lives they lead, the ancient traditions they inspire-whatever the source of your interest, you've spent much of your life to this point immersed in all things draconic. These studies have bolstered your self-confidence and given you a wide range of methods and tactics you can use to impose your will on others.  You've likely chosen to attend the Call for Heroes as a way to seek funds as an adventurer to afford more texts about dragons or perhaps out of a desire to encounter one in real life. Choose two ability boosts. One must be to Strength or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Dragon Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Dragon Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Emancipated",
+            "source": "Age of Ashes Player's Guide pg. 4",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=43",
+            "prerequisites": "",
+            "description": "Until recently, the nation of Ravounel was part of the larger nation of Cheliax, where the church of Asmodeus is the law and slaves are traded freely in the open market. You had the poor fortune to be born into slavery, but the good luck to have grown up in the city of Kintargo. When Ravounel seceded from Cheliax, the leaders of this new nation freed all slaves, and you've wasted no time in exploring and establishing your new life. How and why you've come to Breachill is left to you to decide-but the fact that you feel empowered to determine your own destiny continues to drive you!  The chance to become an adventurer has excited you for some time, as you hope to build a new life for yourself as a hero rewarded with fame and fortune. Joining the Call for Heroes is a great opportunity to find a group to adventure with. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Stealth skill, and the Kintargo Lore skill. You gain the Terrain Stalker skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Stealth",
+                "Kintargo Lore"
+            ],
+            "featsGained": [
+                "Terrain Stalker"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Haunting Vision",
+            "source": "Age of Ashes Player's Guide pg. 4",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=44",
+            "prerequisites": "",
+            "description": "You've been haunted by frightening dreams of fires your whole life. This could be the result of a past, near-death experience with fire or it might have no obvious source that you know of. Recently, you stumbled upon an image, story, or other omen featuring the dragon god of destruction, Dahak, and you were struck with an unnerving sense of deja vu-you've come to think that the draconic deity might have something to do with your dreams, and as such have been studying all you can about the god. Your visions have bolstered your faith as well; even if you don't worship a specific deity, you have a deep passion for matters of faith.  Your latest dream, for the first time, had enough details to identify its setting-in this last dream, you saw the town of Breachill burning. You've decided to join the Call for Heroes hoping to save the town you fear might burn to the ground soon. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Religion skill, and the Dahak Lore skill. You gain the Student of the Canon skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Dahak Lore"
+            ],
+            "featsGained": [
+                "Student of the Canon"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Hellknight Historian",
+            "source": "Age of Ashes Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=45",
+            "prerequisites": "",
+            "description": "The various Hellknight Orders intrigue you, whether you seek to become one of their number yourself, wish to oppose their goals at every turn, or are merely inspired by or curious to learn more about them. You've heard that when the Order of the Nail abandoned Citadel Altaerein, they left behind the deed to the castle so anyone brave enough to explore the ruins and the defenses no doubt left behind would be rewarded with ownership of the abandoned fortress.  You decided to join the Call for Heroes to hoping to gain an opportunity to explore Citadel Altaerein. Choose two ability boosts. One must be to Strength or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Architecture Lore skill. You gain the Courtly Graces skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Architecture Lore"
+            ],
+            "featsGained": [
+                "Courtly Graces"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Local Scion",
+            "source": "Age of Ashes Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=46",
+            "prerequisites": "",
+            "description": "You're from Breachill and have lived there most, if not all, of your life. You might be the son or daughter of a well-known local adventuring family, or a family with a storied tradition of military or other martial service. You likely also have some sort of skill with your hands, as the people of Breachill are very self-sufficient.  The Call for Heroes is one of your hometown's most iconic traditions, and you want to attend so you can prove your own merits to the council-beyond simply those of your family's name. Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Crafting skill, and the Breachill Lore skill. You gain the Specialty Crafting skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Breachill Lore"
+            ],
+            "featsGained": [
+                "Specialty Crafting"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Out-of-Towner",
+            "source": "Age of Ashes Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=47",
+            "prerequisites": "",
+            "description": "You've never been to Breachill, nor do you have roots in the town, but as chance has it you find yourself visiting. You might be here traveling with a friend, visiting an old acquaintance, or merely here to see a new part of the world. Before coming to town, though, you spent many years living with an ancestry other than your own, and your diverse childhood has left you with an open mind and a curious nature.  You're excited to meet new people and cultures, and answering the Call for Heroes seems to be an interesting way to do so. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Diplomacy skill, and a Lore skill thematically associated with the members of the ancestry you grew up with: Dwarf, Elf, Gnome, Goblin, or Halfling. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Reputation Seeker",
+            "source": "Age of Ashes Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=48",
+            "prerequisites": "",
+            "description": "You're likely from Breachill, but unlike the Local Scion, your family has no notable legacy in the area. You might not even have much of a family at all to call your own, and could be an orphan. You've seen so many people make names for themselves that you set out on your own and spent some time abroad in the jungles or deserts of Garund or in the upper reaches of the Darklands-regions that proved too dangerous to remain in for long on your own. You returned home with more caution and knowledge of the world beyond Breachill's borders, but still determined to win fame.  You've decided that joining an adventuring group would be the best way to secure aid in your quest to build your own reputation, and are attending the Call for Heroes to find such allies. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Survival skill, and the Darklands, Desert, or Jungle Lore skill. You gain the Terrain Expertise skill feat (underground if you have Darklands Lore, desert if you have Desert Lore, or forest if you have Jungle Lore).",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Darklands, Desert, or Jungle Lore"
+            ],
+            "featsGained": [
+                "Terrain Expertise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Returning Descendant",
+            "source": "Age of Ashes Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=49",
+            "prerequisites": "",
+            "description": "You aren't from Breachill yourself-you might not even be from Isger or Avistan at all. You've lived a hard life, in any event. You have often had to make tough decisions, and have developed a knack for understanding how things work (and the best way to take them apart) that has helped you support yourself. Recently you discovered that an ancestor was from the town of Breachill and had a modest career as an adventurer. You can't help but wonder if you would have had an easier life if you'd grown up there instead, and have decided to seek out this small town to learn more about it. You've decided to respond to the Call for Heroes to follow in your ancestor's footsteps, either to honor their memory or accomplish the great deeds they did not. Choose two ability boosts. One must be to Dexterity or Wisdom, and one is a free ability boost. You're trained in the Thievery skill, and the Engineering Lore skill. You gain the Pickpocket skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Thievery",
+                "Engineering Lore"
+            ],
+            "featsGained": [
+                "Pickpocket"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Truth Seeker",
+            "source": "Age of Ashes Player's Guide pg. 6",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=50",
+            "prerequisites": "",
+            "description": "Whether you are a local or from out of town, you've heard rumors that Breachill's past contains a hidden secret. Perhaps you've heard strange rumors that the town's founder, Lamond Breachton, was not the hero everyone touts, or maybe your grandmother heard stories from her own grandmother that contradict the town's accepted narrative of its establishment. In the pursuit of the truth, you've learned to navigate the tangles of politics, and to never take anyone's word at face value.  You plan to join the Call for Heroes so that you can make yourself known to the council, or perhaps even ingratiating yourself to them, so you can seek the truth and eventually uncover Breachill's secrets! Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Deception skill, and the Politics Lore skill. You gain the Lie to Me skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Politics Lore"
+            ],
+            "featsGained": [
+                "Lie to Me"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Extinction Curse": [
+        {
+            "name": "Aerialist",
+            "source": "Extinction Curse Player's Guide pg. 4",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=134",
+            "prerequisites": "",
+            "description": "Experienced with trapezes, aerial silks, and hoops, your skill is in performing death-defying stunts high above the ground. The Celestial Menagerie skimped on safety devices such as nets and quality ropes, so you also learned to take a fall better than most. After a harrowing near-death experience involving a cracked trapeze bar, you decided to take your expertise elsewhere. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Acrobatics skill, and the Rope Lore skill. You gain the Cat Fall skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Rope Lore"
+            ],
+            "featsGained": [
+                "Cat Fall"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Animal Wrangler",
+            "source": "Extinction Curse Player's Guide pg. 4",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=135",
+            "prerequisites": "",
+            "description": "You have a long history of working with large circus animals for the Celestial Menagerie, such as performing in an animal act, jostling animals back into their cages, or even sweeping dung out of squalid pens. Mistress Dusklight's ongoing mistreatment of her animals compelled you to quit, and you now strive to ensure animals aren't abused. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in your choice of either the Athletics or Nature skill, as well as a Lore skill related to a particular kind of common animal (such as Equine Lore, Feline Lore, or Pachyderm Lore) You gain a skill feat: Titan Wrestler if you chose Athletics, or Train Animal if you chose Nature.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Nature",
+                "Lore"
+            ],
+            "featsGained": [
+                "Titan Wrestler",
+                "Train Animal"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Barker",
+            "source": "Extinction Curse Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=136",
+            "prerequisites": "",
+            "description": "You're skilled at shouting to catch and keep the attention of passersby. A few well-timed and forcefully spoken words not only get people to notice you but also engage them to respond to you. You may have previously worked as a crier or in a more formal barker capacity with Mistress Dusklight's Celestial Menagerie. Either way, your ability to bully a crowd is impressive. Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Crowd Lore skill. You gain the Group Coercion skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Crowd Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Blow-In",
+            "source": "Extinction Curse Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=137",
+            "prerequisites": "",
+            "description": "You never expected to join a circus, but you were looking for a good place to lie low for reasons of your own. The Circus of Wayward Wonders came together with several different workers and performers a few months ago. Many came from a circus in Escadar called the Celestial Menagerie, but not all of them. It was easy to slip in among the roustabouts. Although you'd planned to move on quickly, the circus folk have adopted you as one of their own, and they don't ask questions about your past. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in your choice of either the Deception or Thievery skill, as well as the Underworld Lore skill. You gain a skill feat: Lengthy Diversion if you chose Deception, or Subtle Theft if you chose Thievery.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Thievery",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Lengthy Diversion",
+                "Subtle Theft"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Butcher",
+            "source": "Extinction Curse Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=138",
+            "prerequisites": "",
+            "description": "You've spent uncounted hours walking up and down crowded and noisy circus stands, inventing innovative means to sell refreshments, food, and novelties at inflated prices. (You might know very little about slaughtering animals; 'butcher' is a circus slang term for a vendor.) The Celestial Menagerie constantly pushed you to figure out how to sell increasingly shoddy toys to children and how to conceal the taste of spoiled treats that should have been discarded days earlier. You peddled disappointment and hated it, so you left to seek a new line of work-although you're not yet willing to leave the circus life altogether. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Mercantile Lore skill. You gain the Read Lips skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Read Lips"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Circus Born",
+            "source": "Extinction Curse Player's Guide pg. 5",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=139",
+            "prerequisites": "",
+            "description": "The itinerant life of a traveling circus performer is nothing new to you; you were born and raised in the circus. You've seen more acts than you can count and grew up hearing the tall tales of circus performers while gathered around their campfires. You've experienced the thrill of captivating crowd ever since you were young. You may have tried a few times to settle down, but the lure of the open road and the glamor of the big top always called you back. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Circus Lore skill. You gain the Experienced Professional skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Circus Lore"
+            ],
+            "featsGained": [
+                "Experienced Professional"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Clown",
+            "source": "Extinction Curse Player's Guide pg. 6",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=140",
+            "prerequisites": "",
+            "description": "Although you've spent time in greasepaint and colorful clothing to amuse crowds, your skills with buffoonery and physical comedy are exceptional whether or not you're in costume. In the employ of Mistress Dusklight's Celestial Menagerie, you spent too many routines distracting an audience from an ill-timed accident or evidence of abused animals or performers. You've had enough of that, and the Celestial Menagerie isn't your home any longer. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Performance skill, and the Clown Lore skill. You gain the Virtuosic Performer skill feat (comedy)",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Clown Lore"
+            ],
+            "featsGained": [
+                "Virtuosic Performer"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Mystic Seer",
+            "source": "Extinction Curse Player's Guide pg. 6",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=141",
+            "prerequisites": "",
+            "description": "You delight crowds by reading minds, telling futures, and contacting spirits. Although much of your work is misdirection and showmanship, your cons have inadvertently awakened a genuine awareness of magic in your mind. This new sense is both thrilling and frightening, and you hope that you can hone it further in the Circus of Wayward Wonders. Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost. You're trained in the Arcana skill, and the Scam Lore skill. You gain the Arcane Sense skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Scam Lore"
+            ],
+            "featsGained": [
+                "Arcane Sense"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Rigger",
+            "source": "Extinction Curse Player's Guide pg. 6",
+            "PFS": "No PFS Data",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=142",
+            "prerequisites": "",
+            "description": "You've worked as a roustabout to erect tents and set up rigging for acrobatic performances; you've sometimes even aided aerialists and acrobats in their death-defying training. Even though your work is often done before the crowds arrive, you know your skills contribute to the success and safety of the circus. Mistress Dusklight treats her roustabouts as little more than slaves, and you've resolved to join a company where your expertise is appreciated. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Athletics skill, and the Circus Lore skill. You gain the Combat Climber skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Circus Lore"
+            ],
+            "featsGained": [
+                "Combat Climber"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Pathfinder Society": [
+        {
+            "name": "Demon Slayer",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=156",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 5 of the Pathfinder Society organized play campaign. For over a century, Mendev led a multinational coalition against ever-growing abyssal invaders in the Worldwound, and the Pathfinder Society aided in the so-called Fifth Crusade that ultimately sealed the planar rift and defeated its demon armies. You might be a hardened recruit who clashed with the demons, or perhaps you were a survivor who lost everything to the fiendish armies and narrowly escaped-or was rescued by Pathfinders. Your exposure to the Worldwound has taught you vital lessons in identifying fiends and their magic. Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost. You're trained in the Religion skill, and the Demon Lore skill. You gain the Recognize Spell skill feat. Add Abyssal to the list of additional languages you can learn for having a high Intelligence modifier.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Demon Lore"
+            ],
+            "featsGained": [
+                "Recognize Spell"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Early Explorer",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=148",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Seasons 0 of the Pathfinder Society organized play campaign. In the past decade, the Pathfinder Society has clashed with demonic armies, meddled in politics, and more, but you joined the organization before everything seemed so complicated. Whether you're a dedicated scholar of ruins or an explorer who just longs for months-long expeditions into the wilderness, you're a Pathfinder to explore, report, and cooperate. Choose two ability boosts. One must be to Strength or Wisdom, and one is a free ability boost. You're trained in the Survival skill, and the Pathfinder Society Lore skill. You gain the Forager skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Pathfinder Society Lore"
+            ],
+            "featsGained": [
+                "Forager"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Faction Opportunist",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=163",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 9 of the Pathfinder Society organized play campaign. As the Pathfinder Society's influence has grown, so too did many of its factions become wealthier and more powerful. These factions relied on a host of Pathfinders and independent operatives alike to establish trade networks, shape national politics, and more, and you were among the specialists who helped one of these factions realize its goal. These events provided you countless opportunities to develop your own contacts and negotiating skills.   Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost.   You're trained in the Diplomacy skill, plus either Guild Lore, Heraldry Lore, or Mercantile Lore. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Guild Lore",
+                "Heraldry Lore",
+                "Mercantile Lore"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Finadar Leshy",
+            "source": "Pathfinder Society Scenario #1-15: The Blooming Catastrophe pg. 35",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=143",
+            "prerequisites": "Prerequisites Leshy ancestry",
+            "description": "You are a leshy from Finadar Forest, originally created under the corruption of a cyclopean monolith. Though the Pathfinder Society managed to sever the monolith's connection, freeing the forest and your people from its influence, you retain a trace, unnerving connection to the Abyss.Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Abyssal Lore skill. You gain the Intimidating Glare skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Abyssal Lore"
+            ],
+            "featsGained": [
+                "Intimidating Glare"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Former Aspis Agent",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=159",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 7 of the Pathfinder Society organized play campaign. For more than a century, the Pathfinder Society has clashed with the avaricious and underhanded Aspis Consortium, and several years ago the Society dealt its rival a decisive blow. You may be one of the few survivors of a doomed Aspis expedition, or perhaps you chafed at the Consortium's villainous practices and defected to the Pathfinders. No matter your reasons, you know how to be efficient and ruthless when the circumstances demand. Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost. You're trained in the Intimidation skill, and the Aspis Consortium Lore skill. You gain the Group Coercion skill feat. You gain access to any uncommon options as though you were a member of the Aspis Consortium.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Intimidation",
+                "Aspis Consortium Lore"
+            ],
+            "featsGained": [
+                "Group Coercion"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Iolite Trainee Hobgoblin",
+            "source": "Pathfinder Society Scenario #1-19: Iolite Squad Alpha pg. 30",
+            "PFS": "PFS Limited",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=146",
+            "prerequisites": "Prerequisites Hobgoblin Ancestry",
+            "description": "The Iolite Squad was Oprak's first foray into training hobgoblins for Pathfinder membership. You've added the archival and archaeological skills they sent back to Oprak into your military training.Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Society skill, and the Warfare Lore skill. You gain the Sign Language skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Warfare Lore"
+            ],
+            "featsGained": [
+                "Sign Language"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Ruby Phoenix Enthusiast",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=153",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 3 of the Pathfinder Society organized play campaign. Named for the legendary sorcerer Hao Jin, the Ruby Phoenix Tournament occurs once every 10 years in Goka and attracts extraordinary talent from across the world. You might have begun training for the tournament but never participated, or perhaps you entered the tournament only to be defeated by (and inspired to join) the Pathfinder Society. Either way, your dedicated training prepares you for the rigors of the adventuring lifestyle. Choose two ability boosts. One must be to Strength or Dexterity, and one is a free ability boost. You're trained in the Athletics skill, and the Gladiatorial Lore skill. You gain the Combat Climber skill feat. In addition, you gain access to one of the following uncommon monk weapons: kama, nunchaku, sai, shuriken, or temple sword.",
+            "abilityBoosts": [
+                "Strength",
+                "Dexterity"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Gladiatorial Lore"
+            ],
+            "featsGained": [
+                "Combat Climber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Savior of Air",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=161",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 8 of the Pathfinder Society organized play campaign. Upon securing the Untouchable Opal, an artifact of extraordinary power, the Pathfinder Society endeavored to free the benevolent demigod Ranginori, who was trapped within the virtually unbreakable prison. You might have joined the Pathfinder Society in its expeditions to the Elemental Planes, or you might have lived on one of those planes before learning of the Society from these Pathfinder agents. You are no stranger to navigating precarious terrain as a result. Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Acrobatics skill, and the Elemental Lords Lore skill or a Lore skill related either to one of the Elemental Planes (such as Plane of Air Lore). You gain the Cat Fall skill feat. Add Auran to the list of additional languages you can learn for having a high Intelligence modifier.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Acrobatics",
+                "Elemental Lords Lore",
+                "Lore"
+            ],
+            "featsGained": [
+                "Cat Fall"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Scholar of the Sky Key",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=157",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 6 of the Pathfinder Society organized play campaign. The unfamiliar technology of Numeria's Silver Mount still baffles Society scholars, yet you are one of the innovators who discovered how to operate a handful of these futuristic tools-possibly after surviving more than a few explosions. The Society might have recruited you for your esoteric abilities, or you might have sought out the Society's protection in escaping the covetously vile Technic League. Even if your understanding of advanced technology is imperfect, your hard-learned lessons are invaluable in deciphering and repairing gear. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Crafting skill, and the Engineering Lore skill. You gain the Quick Repair skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Crafting",
+                "Engineering Lore"
+            ],
+            "featsGained": [
+                "Quick Repair"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Shadow Lodge Defector",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=151",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 2 of the Pathfinder Society organized play campaign. You were among the Pathfinders recruited by the devious Shadow Lodge, lured in by promises of wealth, reform, justice, or revenge. You might have fought against the Society's loyal agents, helped sabotage the Pathfinders' reputation in distant countries, or even infiltrated the far-flung lodges as a spy. You've since made peace with and rejoined the Pathfinder Society, yet the underhanded reflexes and skills you learned are hard to forget. Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost. You're trained in the Deception skill, and the Underworld Lore skill. You gain the Lie to Me skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Underworld Lore"
+            ],
+            "featsGained": [
+                "Lie to Me"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Shadow War Survivor",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=150",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 1 of the Pathfinder Society organized play campaign. Countless factions have fought for influence in Absalom for millennia, and for decades these groups worked through the Pathfinder Society to better control the City at the Center of the World. Perhaps you were ones of these agents who clashed with other operatives during the so-called Shadow War. Or you might have been an unintended victim of these clandestine clashes, inspiring you to join the Society and stop the conflict from within. Whatever the reason, navigating the Shadow War has left you politically savvy and informed. Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost. You're trained in the Society skill, and the Absalom Lore skill. You gain the Streetwise skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Absalom Lore"
+            ],
+            "featsGained": [
+                "Streetwise"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Tapestry Refugee",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=164",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 10 of the Pathfinder Society organized play campaign. Within her magnificent museum demiplane, the sorcerer Hao Jin extracted and preserved countless sites and cultures. The demiplane's unraveling magic forced the Pathfinder Society to evacuate the many inhabitants recently, and you were among the refugees who returned to the Material Plane after centuries of isolation. Whether you joined the Society out of gratitude, curiosity, or desperation, you are hardened by your harrowing flight from your doomed home. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in your choice of either the Medicine or Stealth skill, as well as a Lore skill related to the terrain you lived in while on the demiplane (such as Cave Lore or Desert Lore). You gain the Assurance skill feat with the skill you chose to become trained in (Medicine or Stealth).",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Medicine",
+                "Stealth",
+                "Lore",
+                "Cave Lore",
+                "Desert Lore"
+            ],
+            "featsGained": [
+                "Assurance"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Thassilonian Delver ",
+            "source": "Organized Play Foundation",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=155",
+            "prerequisites": "",
+            "description": "PFS Note You can select this background only if you have earned credit for at least 5 First Edition scenarios from Season 4 of the Pathfinder Society organized play campaign. As archaeologists uncovered and explored ever-larger numbers of Thassilonian ruins, you were among the eager explorers who sought out the Runelords' ancient secrets. You may have been the apprentice to another Pathfinder who perished on an expedition, leaving you their discoveries and notes. Or perhaps you explored several of these sites yourself, quickly learning to parse the arcane secrets before lest the eldritch magic extinguish your life. Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost. You're trained in the Arcana skill, and the Thassilonian History Lore skill. You gain the Arcane Sense skill feat. Add Thassilonian to the list of additional languages you can learn for having a high Intelligence modifier.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Thassilonian History Lore"
+            ],
+            "featsGained": [
+                "Arcane Sense"
+            ],
+            "descSpecial": {}
+        }
+    ],
+    "Agents of Edgewatch": [
+        {
+            "name": "Ex-Con Token Guard",
+            "source": "Agents of Edgewatch Player's Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=190",
+            "prerequisites": "",
+            "description": "Not everyone starts life on easy street-your own experience is testament to that. You took a wrong turn at some point early on and became a career criminal. Perhaps you were a petty pickpocket, or maybe you've even murdered someone. Either way, your crimes landed you with a transformative prison sentence in the Brine prison. Only then did you realize that something needed to change. After your release, you dedicated yourself to helping other downtrodden individuals and those forced to resort to crime to survive. You joined the Coins District Guard, but soon learned that this precinct was a haven for the very corruption you sought to undo. Your efforts at reform never took root and you feared that your decision to become an officer of the law was a huge mistake.  You transferred to the Edgewatch, the Precipice Quarter's new precinct, in the hope that you might meet others who sought to help-not exploit-Absalom's misguided.  Choose two ability boosts. One must be to Dexterity or Charisma, and one is a free ability boost. You're trained in the Thievery skill and your choice of Legal Lore or Underworld Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Token Guards and convicted criminals such as prison inmates. You gain the Pickpocket skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Thievery",
+                "Legal Lore",
+                "Underworld Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Pickpocket"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Godless Graycloak",
+            "source": "Agents of Edgewatch Player's Guide pg. 6",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=191",
+            "prerequisites": "",
+            "description": "You were a member of a church once, and you saw some things among Absalom's religious elite that put you off piety for good. Maybe it was one too many beggars turned away at the temple's front door, or maybe it was a high-ranking priests consistent abuses of power. What got to you most, though, was that according to just about every belief system out there, sinners and saints, priests and paupers were all alike in one key way: they never saw retribution or accolades until buried 6 feet under. You wanted more from Absalom. You wanted more from the world. You wanted justice now, on this plane, not in some indeterminate afterlife. So you left the church and wandered the city, a ghost of your former self.  You finally found a like mind in Captain Runewulf, \"the Unbeliever\", whose reputation and similar distaste for religion inspired you to join the Graycloaks. As a sworn protector of the Ascendant Court, you didn't differentiate between Sarenites or Pharasmins, Iomedaeans or Norgorberites; if you saw someone in danger, you put your life on the line to save them, whatever their place within or outside a church.  Your good record has earned you a transfer-temporary or not, the choice is yours-to the newly formed Edgewatch, where you'll use your authority to guard the lives of not just Absalomians, but all who have come to your grand city to experience its wonders. Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost. You're trained in the Religion skill and your choice of a specific religion Lore skill (such as Iomedae Lore or Norgorber Lore). You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Graycloaks, priests, and clerics. You gain the Quick Identification feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Religion",
+                "Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Quick Identification"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Grizzled Muckrucker",
+            "source": "Agents of Edgewatch Player's Guide pg. 7",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=192",
+            "prerequisites": "",
+            "description": "You've served on the Muckruckers, the unofficial guards of the flooded Puddles district. The pay's no good, the conditions are squalid, and you've seen things during your time on the force that've made you question your career entirely. Perhaps you joined the group out of a sense of duty to your fellow Absalomians, or maybe you felt an obligation to help restore your apocalyptic home district to some semblance of normalcy. Either way, the traumas you've endured, the double-crossers who've betrayed you, the wretched monsters that have crawled out of the muck to assail you-it's enough to turn an officer to weary cynicism or self-destruction through merciful drink.  Thankfully, you found an out: an invitation to transfer to the newly formed Edgewatch. You accepted the offer in the hope that some fresh experience in a new district, surrounded by new people, might reignite the hope and passion you felt for the job so long ago.  Choose two ability boosts. One must be to Constitution or Charisma, and one is a free ability boost.  You're trained in the Survival skill, as well as either Labor Lore or Underworld Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Muckruckers, mercenaries, and adventurers. You gain the Experienced Tracker skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Survival",
+                "Labor Lore",
+                "Underworld Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Experienced Tracker"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Harbor Guard Moonlighter",
+            "source": "Agents of Edgewatch Player's Guide pg. 7",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=193",
+            "prerequisites": "",
+            "description": "The Harbor Guard isn't known for being the most honorable precinct in town. A few years after you joined the force, you became disillusioned by the rampant corruption within the precinct and the district at large. One night, you stumbled on an ad for a local monster hunter's guild. You joined on a whim, but fell in love with the swashbuckling lifestyle of an independent bounty hunter. You've since earned quite a reputation for your nocturnal adventures; everyone still knows that you're a Harbor Guard, but stories of your dungeon-delving adventures have long overshadowed that facet of your life. Unfortunately, long nights of monster-hunting have negatively impacted your performance at your day job, so maybe it wasn't a surprise when your supervising officer put in a transfer request for you, spelling the end of your plucky nighttime antics with that particular guild.  Despite the decline in your performance, Lieutenant Lavarsus of Edgewatch sees potential (and even, maybe, a bit of himself) in you. You're eager to be on a new unit and for the chance to bring your monster-hunting skills to a district that has been plagued by such supernatural beasts for far too long.  Choose two ability boosts. One must be to Strength or Constitution, and one is a free ability boost.  You're trained in the Athletics skill and your choice of Sailing Lore or Hunting Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Harbor Guards, ship captains, and freelance adventurers. You gain the Quick Jump skill feat.",
+            "abilityBoosts": [
+                "Strength",
+                "Constitution"
+            ],
+            "skillsTrained": [
+                "Athletics",
+                "Sailing Lore",
+                "Hunting Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Quick Jump"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Learned Guard Prodigy",
+            "source": "Agents of Edgewatch Player's Guide pg. 7",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=194",
+            "prerequisites": "",
+            "description": "For some, the nuts and bolts of keeping the peace are practically second nature. Such is the case for you, a member of the Learned Guard with an incredible mind for investigation as well as a gift for understanding magic. You probably aren't a hit with your peers, who find your intellect and natural gift of deduction perhaps a bit off-putting, but when left to your own devices you excel, and you get along well with professors and mages such as those who work in Forae Logos or the Arcanamirium.  After no shortage of debating the pros and cons, you decided to transfer to the Edgewatch precinct. Sure, you have a keen understanding of the theories and principles behind law enforcement, but you've reasoned that in order to be a truly effective guard you'll need some first-hand experience in a high-risk area nabbing suspects and protecting innocents- all the while taking fastidious notes and writing your grand thesis on the merits and shortcomings of Absalom's laws.  Choose two ability boosts. One must be to Intelligence or Wisdom, and one is a free ability boost.  You're trained in your choice of the Arcana or Occultism skill, as well as Legal Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Learned Guards and with academics such as librarians and scholars. You gain the Recognize Spell skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Arcana",
+                "Occultism",
+                "Legal Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Recognize Spell"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Political Scion",
+            "source": "Agents of Edgewatch Player's Guide pg. 8",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=195",
+            "prerequisites": "",
+            "description": "Like your parents and your parents before them, you initially followed the long path toward politics from an early age. Your close association with Absalom's upper echelons put you in touch with the city's various military or special operations units-the First Guard, the Wave Riders, the Varlokkur- though you avoided any actual duty with these groups. Thanks to your strict upbringing and the connections of your family, you soon became a lauded and highly respected member of Absalom's political elite. But you couldn't stifle a certain feeling that you were destined for more than simply filling the pointed shoes of your forebears. Despite your easily earned accolades and a relatively cushy life as a young lawyer or councilmember, you sought to do more with your diplomatic training and not live out the exact same life as your ancestors.  Your decision to transfer to the Edgewatch has rubbed your traditionalist family the wrong way, and they've cut off the financial aid they've provided you your whole life. But you don't care-you know you're doing the right thing by taking on the rough jobs of a low-ranking guard, and you're ready to shine based on your own merits, not those of your lofty kin.  Choose two ability boosts. One must be to Constitution or Intelligence, and one is a free ability boost.  You're trained in the Diplomacy skill and Legal Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with members of Absalom's political establishment. You gain the Hobnobber skill feat.",
+            "abilityBoosts": [
+                "Constitution",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Diplomacy",
+                "Legal Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Hobnobber"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Post Guard of All Trade",
+            "source": "Agents of Edgewatch Player's Guide pg. 8",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=196",
+            "prerequisites": "",
+            "description": "Not all cops are passionate about their jobs. For some, the pursuit of justice is just another way to pay the bills. Honestly, it was probably the Post Guard's generous time-off policy that drew you to their service, and during your yearly sabbaticals you've dabbled in hobbies as diverse as fishing, baking, or even stand-up comedy. Even while on duty, you're probably idly fiddling with a lucky coin or practicing magic tricks with a deck of cards. You probably irritate your fellow guards a bit with your non sequiturs, casual attitude, and tendency to daydream, but results don't lie, and more often than not you prove your worth when the chips are down.  For all the excitement of guarding Absalom's Postern Gate, the Post Guard wasn't really the right fit for someone as distractible as yourself, so your boss put in a 'promotion' for you to transfer to the newly formed Edgewatch. You're all for the reassignment, since it will put you smack in the middle of the most entertaining and diverse gathering of the century, the Radiant Festival.  Choose two ability boosts. One must be to Dexterity or Intelligence, and one is a free ability boost.  You're trained in the Performance skill, a Lore skill of your choice, and you gain a bonus language. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Post Guards. You gain the Dubious Knowledge skill feat.",
+            "abilityBoosts": [
+                "Dexterity",
+                "Intelligence"
+            ],
+            "skillsTrained": [
+                "Performance",
+                "Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Dubious Knowledge"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sally Guard Neophyte",
+            "source": "Agents of Edgewatch Player's Guide pg. 8",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=197",
+            "prerequisites": "",
+            "description": "You joined the Sally Guard, Westgate's guard precinct, at an early age, bringing with you the requisite steel armor, sword, and lance, though your gear is of dubious make. The other guards may have suspected that you were a novice with less combat experience than them; if so, you proved their suspicions on your first day of training when your mount immediately threw you in the mud. A supervisor took mercy on you and offered to transfer you to another guard unit in the city, promising that you'd have a place on the Sally Guard when you decided you were ready for the challenge.  Biting your lip in shame, you took the Edgewatch reassignment in order to gain the experience necessary to go back to your home district with your head held high. You'll prove them wrong, one way or another, and show everyone that you can protect the ones you hold most dear.  Choose two ability boosts. One must be to Constitution or Wisdom, and one is a free ability boost.  You're trained in the Nature skill and your choice of Hunting Lore or Stabling Lore. You start out with a riding horse, as well as a suit of shoddy half-plate armor, a shoddy longsword, and a shoddy lance (see here for the rules on shoddy items).",
+            "abilityBoosts": [
+                "Constitution",
+                "Wisdom"
+            ],
+            "skillsTrained": [
+                "Nature",
+                "Hunting Lore",
+                "Stabling Lore"
+            ],
+            "featsGained": [],
+            "descSpecial": {}
+        },
+        {
+            "name": "Sleepless Suns Star",
+            "source": "Agents of Edgewatch Player's Guide pg. 9",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=198",
+            "prerequisites": "",
+            "description": "Among your fellow guards who patrol the Foreign Quarter, you're something of a big deal. Your good work and big personality have made a big enough splash that word has gotten out about your status as a rising star among the watchdogs of Absalom. Your popularity has also earned you the trust of many citizens of the Foreign Quarter.  Your laudable performance has earned you a transfer to the newly formed Edgewatch in the Precipice Quarter, where you'll put your formidable reputation to good use by patrolling the Radiant Festival and ensuring the safety of Absalom's most vulnerable visitors.  Choose two ability boosts. One must be to Wisdom or Charisma, and one is a free ability boost.  You're trained in the Society, plus either Gladiatorial Lore or Genealogy Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with members of the Sleepless Suns and residents of the Foreign Quarter. You gain the Multilingual skill feat.",
+            "abilityBoosts": [
+                "Wisdom",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Society",
+                "Gladiatorial Lore",
+                "Genealogy Lore",
+                "Deception",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Multilingual"
+            ],
+            "descSpecial": {}
+        },
+        {
+            "name": "Undercover Lotus Guard",
+            "source": "Agents of Edgewatch Player's Guide pg. 9",
+            "PFS": "PFS Standard",
+            "link": "https://2e.aonprd.com/Backgrounds.aspx?ID=199",
+            "prerequisites": "",
+            "description": "It's a well-known secret that for every playhouse in the Ivy District, there's an underground criminal element lurking somewhere in the shadows. To get intel on the occultists, assassins, and thieves' guilds that pull the strings of power in the Ivy District, the Lotus Guard trains some of the best undercover agents and operatives in all of Absalom. You're one such agent, and you've put your life on the line more times than you can count by getting close to the Ivy's most dangerous criminals. Your risky missions and thrill-seeking derring-do have earned you many accolades-but also no shortage of enemies.  You transferred to the Edgewatch after your cover was unexpectedly blown and you needed a safe place to lie low away from the Ivy District. With your mastery of disguise and your ability to confidently converse with criminal masterminds, it won't be long before you've made yourself an indispensable undercover operator in this precinct as well.  Choose two ability boosts. One must be to Intelligence or Charisma, and one is a free ability boost.  You're trained in the Deception skill, Art Lore, and Underworld Lore. You gain a +1 circumstance bonus to Deception, Diplomacy, and Intimidation checks to interact with Lotus Guards and high-ranking criminals like guild masters, gang leaders, and mob bosses. You gain the Charming Liar skill feat.",
+            "abilityBoosts": [
+                "Intelligence",
+                "Charisma"
+            ],
+            "skillsTrained": [
+                "Deception",
+                "Art Lore",
+                "Underworld Lore",
+                "Diplomacy",
+                "Intimidation"
+            ],
+            "featsGained": [
+                "Charming Liar"
+            ],
+            "descSpecial": {}
+        }
+    ]
+}

--- a/buildBackgrounds-aon.py
+++ b/buildBackgrounds-aon.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from bs4 import BeautifulSoup
+from bs4 import Tag
+import requests
+import json
+import datetime
+import codecs
+import time
+import re
+
+###TODO: Some backgrounds, like "Undercover Lotus Guard", get conditional bonuses to skills without giving you training in them.  Right now those skills get put in 'skillsTrained', which is incorrect.  Find some way to consistently ignore those extra skills.
+###TODO: Right now we don't keep italic or bold text markers.  Should we?  If not, we should let the "This tag wasn't captured" section know to ignore <i> tags.
+ 
+backgroundHolder = {}
+backgroundHolder['name'] = 'Pathfinder 2.0 background list'
+backgroundHolder['date'] = datetime.date.today().strftime("%B %d, %Y")
+validAbilities = ['Strength', 'Dexterity', 'Constitution', 'Intelligence', 'Wisdom', 'Charisma']#For when we look for a given background's ability boosts
+
+
+backgroundLinks = {
+        "Backgrounds.aspx": "General", 
+        "Backgrounds.aspx?Legacy=true": "Legacy",
+        "Backgrounds.aspx?Regional=true": "Regional",
+        "Backgrounds.aspx?Group=1": "The Fall of Plaguestone",
+        "Backgrounds.aspx?Group=2": "Age of Ashes",
+        "Backgrounds.aspx?Group=3": "Extinction Curse",
+        "Backgrounds.aspx?Group=4": "Pathfinder Society",
+        "Backgrounds.aspx?Group=5": "Agents of Edgewatch"
+    } 
+ 
+ 
+def encoder(words):
+    encoded = words.replace(u"\u2019", "'")
+    encoded1 = encoded.replace(u"\u2014", "-")
+    encoded2 = encoded1.replace(u"\u2011", " ")
+    encoded3 = encoded2.replace(u'\u201c', "'")
+    encoded4 = encoded3.replace(u'\u201d', "'")
+    encoded5 = encoded4.replace(u'\u2026', "...")
+    return encoded5
+
+
+def get_detail_entry(backEntry):
+    detail = {}#Package of a given background
+    description = []
+    abilityBoosts = []
+    skillsTrained = []
+    featsGained = []
+    descSpecial = {}
+    prerequisites = []
+        
+    if str(backEntry.get_text()).endswith("Background"):#Only grabs the entries with "Background" at the end, hopefully avoiding things we don't care about
+
+        entryName = (str(backEntry.get_text()))[:-10]#removes "Background" from the end of the text we found
+        detail['name'] = entryName
+        
+        detail['source'] = backEntry.find_next_sibling("a").get_text()
+        
+        #link and PFS handling
+        if (backEntry.find('a').get('href')) == 'PFS.aspx':#some entries don't have PFS markers at all, making us navigate links differently
+            detail['PFS'] = str(backEntry.find('a').span.img.get('alt'))
+            if (backEntry.find('a').find_next_sibling('a').get('href').startswith("Backgrounds")):#If there's a PFS link, the thing after it is the background page link
+                detail['link'] = str("https://2e.aonprd.com/" + backEntry.find('a').find_next_sibling('a').get('href'))
+        elif (isinstance(backEntry.previous_sibling, Tag)) and (backEntry.previous_sibling.find_next('a', attrs={"href": "PFS.aspx"})):#Some of the initial broken entries need special treatment to get the PFS data
+            detail['PFS'] = str(backEntry.previous_sibling.find_next('a', attrs={"href": "PFS.aspx"}).span.img.get('alt'))
+            if (backEntry.find('a').get('href').startswith("Backgrounds")):#If there's no PFS link, this link should be the background link.
+                detail['link'] = str("https://2e.aonprd.com/" + backEntry.find('a').get('href'))
+        else:
+            detail['PFS'] = "No PFS Data"
+            if (backEntry.find('a').get('href').startswith("Backgrounds")):#If there's no PFS link, this link should be the background link.
+                detail['link'] = str("https://2e.aonprd.com/" + backEntry.find('a').get('href'))
+
+        #Set our pointer, skipping over whitetext and sup tags
+        descPoint = backEntry.find_next_sibling("a").next_sibling
+        if (descPoint.name is None) and (descPoint.strip() == ''):#skip over whitespace
+            descPoint = descPoint.next_sibling
+        while descPoint.name == 'sup':#Some things have sup tags, some don't.  We need to skip over said tags.
+            descPoint = descPoint.next_sibling
+        
+        while descPoint != None and descPoint.name != "h2" and descPoint.name != "h3" and descPoint.next_sibling != None:
+            if isinstance(descPoint, Tag):#Note that our `from bs4 import Tag` is necessary to check for the Tag type
+                
+                #Bold block
+                if (descPoint.name == 'b'):#Ability boosts, Activates, and Prerequisites (including prereq Regions) are all in bold <b> tags
+                    if (str(descPoint.text) == "Activate"):#Activate, like in the "Cursed" background
+                        descSpecial['specType'] = str(encoder(descPoint.text))
+                        descSpecial['specAction'] = str(encoder(descPoint.find_next_sibling('img').get('alt')))
+                        descSpecial['specDescription'] = []
+                        if descPoint.find_next_sibling('a').get('href').startswith("Traits"):
+                            descSpecial['specTrait'] = descPoint.find_next_sibling('a').text
+                        while descPoint != None and descPoint.name != "h2" and descPoint.name != "h3":
+                            if descPoint.string != None:
+                                if descSpecial['specDescription']:
+                                    descSpecial['specDescription'][-1] = str(descSpecial['specDescription'][-1] + descPoint.string)
+                                else:
+                                    descSpecial['specDescription'].append(str(descPoint.string))
+                            descPoint = descPoint.next_sibling
+                        if descSpecial['specDescription']:
+                            descSpecial['specDescription'][-1] = encoder(descSpecial['specDescription'][-1].rstrip())#rstrip gets rid or right-trailing whitespace
+                            
+                    elif (str(descPoint.text) in ("Prerequisites", "Region")):#Prerequisites, like in the "Hookclaw Digger" background, including Regional prerequisites
+                        prerequisites.append(str(descPoint.text))
+                        while (descPoint.next_sibling != None) and not ((descPoint.name == None) and (descPoint.next_sibling.name == None)):#We're checking if both the current point and the following point are tagless text.  If they are, then we've found a linebreak, and we want to break out of the loop.
+                            descPoint = descPoint.next_sibling
+                            if (descPoint.name == "a"):
+                                prerequisites.append(str(descPoint.text))
+                            else:
+                                prerequisites.append(str(descPoint))
+                        descPoint = descPoint.next_sibling
+                        
+                    elif (str(descPoint.text) in validAbilities):#Valid ability boosts
+                        abilityBoosts.append(str(descPoint.text))
+                        
+                    else:
+                        print ("We didn't handle this bold text: " + str(descPoint.text))
+                
+                #Underlined block
+                elif descPoint.name == 'u':#Most skill and feat links are <u>nderlined
+                    if descPoint.find('a').get('href').startswith("Skills"):
+                        skillsTrained.append(str(descPoint.text))
+                    elif descPoint.find('a').get('href').startswith("Feats"):
+                        featsGained.append(str(descPoint.text))
+                elif descPoint.name == 'a':#...Some are underlined with an <a> tag's style attribute
+                    if descPoint.get('href').startswith("Skills"):
+                        skillsTrained.append(str(descPoint.text))
+                    elif descPoint.get('href').startswith("Feats"):
+                        featsGained.append(str(descPoint.text))
+                        
+                elif descPoint.name == 'h1':#There are some regional categories that we can ignore, stored in h1 tags
+                    pass
+                        
+                else:
+                    print("This tag wasn't captured:" + str(descPoint))
+                    
+                #Description block
+                if description:#if description already has elements
+                    if (isinstance(descPoint, Tag)) and (descPoint.name != "h2"): 
+                        description[-1] = str(description[-1] + encoder(descPoint.text))#We need to fuse the tag with both halves of the text block it's inside of
+                    elif (descPoint.name != "h2"):
+                        description[-1] = str(description[-1] + encoder(descPoint))
+                else:#if description is empty, there's nothing on that side to fuse with.
+                    if (isinstance(descPoint, Tag)) and (descPoint.name != "h2"):
+                        description.append(str(encoder(descPoint.text)))
+                    elif (descPoint.name != "h2"):
+                        description.append(str(encoder(descPoint)))
+                if not isinstance(descPoint.next_sibling, Tag):#This fuses the latter half of the text
+                    description[-1] = str(description[-1] + encoder(descPoint.next_sibling))
+                    descPoint = descPoint.next_sibling#Skip over the text we already handled
+                    
+            else:#if it's not a tag, we just append it to the description
+                description.append(str(encoder(descPoint)))
+                
+            if descPoint.nextSibling != None and descPoint.name != "h2" and descPoint.name != "h3":
+                descPoint = descPoint.next_sibling
+
+        #Setting detail, so that we can return it all in one nice background package
+        description[-1] = description[-1].rstrip()#gets rid of all the extra whitespace at the end of the description
+        detail['prerequisites'] = ''.join(prerequisites)
+        detail['description'] = ' '.join(description)
+        detail['abilityBoosts'] = abilityBoosts
+        detail['skillsTrained'] = skillsTrained
+        detail['featsGained'] = featsGained
+        detail['descSpecial'] = descSpecial
+    #print (detail)
+    return detail
+
+
+def get_detail_list(eachEntry):
+   
+    detail_list = []#Package of everything from the page
+    res = requests.get("https://2e.aonprd.com/" + eachEntry)
+    res.raise_for_status()
+    soup = BeautifulSoup(res.text, 'lxml')
+
+    for linebreak in soup.find_all('br'):
+        linebreak.extract()
+    main = soup.find("div", {'id': 'main'})
+    
+    backEntries = main.find_all("h2")#pulls out each h2 section into items in a list
+    
+    ###This next block is for handling the source's broken HTML tags.  If the source is ever fixed, this should be commented out.
+
+    if backgroundLinks[eachEntry] in ['General', 'Legacy', 'Regional', 'Pathfinder Society', 'Agents of Edgewatch']:#These pages have their first background entries broken, so we wrap it up in an h2 tag.
+        wrapper = soup.new_tag('h2')
+        backEntries[1] = backEntries[1].parent.next_sibling.wrap(wrapper)
+        backEntries[1].string.replace_with(str(backEntries[1].string + "Background"))
+        #print ("Wrapped: " + str(backEntries[1]))
+    
+    ###
+    
+    del backEntries[0]#We don't need the first entry, because it's not a background entry.
+    
+    for backEntry in backEntries:#for each h2 section in our list
+        detail_list.append(get_detail_entry(backEntry))
+
+    return detail_list
+ 
+
+
+
+for eachEntry in backgroundLinks:
+    backgroundHolder[backgroundLinks[eachEntry]] = get_detail_list(eachEntry)#Tags each page with its name ("General", "Regional", etc.)
+
+
+json_data = json.dumps(backgroundHolder, indent=4)
+# print(json_data)
+filename = "backgrounds_aon-pf2.json"
+f = open(filename, "w")
+f.write(json_data)
+f.close


### PR DESCRIPTION
Because this is entirely different code from the existing non-CUP background builder, it's under a different filename.  There are still 2 TODOs, but it's in a decent state otherwise.  The TODOs are: 
1) Some backgrounds have skills that are not to-be-trained, but those skills are being incorrectly picked up by the skillTrained field. 
2) I don't know how we should be handling bold and italic text.  Should we keep it?  Right now we drop the markers from the description.