### PR TITLE
Listified divine abilities.  Grabs philosophies as well now.

### DIFF
--- a/deities-pf2.json
+++ b/deities-pf2.json
@@ -1,6 +1,6 @@
 {
     "name": "Pathfinder 2.0 deities list",
-    "date": "January 21, 2021",
+    "date": "March 27, 2021",
     "deities": [
         {
             "name": "Abadar",
@@ -26,7 +26,6 @@
             "Edicts": "bring civilization to the frontiers, earn wealth through hard work and trade, follow the rule of law",
             "Anathema": "engage in banditry or piracy, steal, undermine a law-abiding court",
             "Areas of Concern": "cities, law, merchants, and wealth",
-            "Divine Ability": "Constitution or Intelligence",
             "divinterSource": "Gods & Magic pg. 13",
             "Minor Boon": "Abadar warns his favored against those who might unfairly take advantage. Once, when someone rolls a success on a Deception check to Lie maliciously to you and you alone, they get a critical failure instead. Abadar typically chooses to grant this boon in response to an extremely consequential lie.",
             "Moderate Boon": "Abadar blesses all your enterprises, leading to financial success as all your ventures always seems to work out. If you roll a critical failure at a check to Earn Income, you get a failure instead. If you roll a success on a check to Earn Income, you earn twice the usual amount of income.",
@@ -49,7 +48,13 @@
                 "7th:": "magnificent mansion"
             },
             "text": "Abadar is worshipped as the god of cities, law, merchants, and wealth. Abadar's cathedral-banks are found in many cities and places where order thrives or is gaining a foothold. Aristocrats, city guards, merchants, and those working in legal practice or who have the well-being of their community on their mind are common worshippers of the god of cities, along with dwarves in general. Abadaran priests living in cities often serve as judges, lawyers, and clerks, while those who live on the frontier work as roving magistrates, acting as judge, jury, and executioners in the name of order.",
-            "divinterDesc": "Abadar's gifts take the form of riches, while his ire tends to cause offenders to lose wealth."
+            "divinterDesc": "Abadar's gifts take the form of riches, while his ire tends to cause offenders to lose wealth.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Asmodeus",
@@ -72,7 +77,6 @@
             "Edicts": "negotiate contracts to your best advantage, rule tyrannically and torture weaker beings, show subservience to your betters",
             "Anathema": "break a contract, free a slave, insult Asmodeus by showing mercy to your enemies",
             "Areas of Concern": "contracts, pride, slavery, and tyranny",
-            "Divine Ability": "any, though characters who commit themselves to Asmodeus this way have their souls bound to the Dark Prince for all eternity",
             "divinterSource": "Gods & Magic pg. 15",
             "Minor Boon": "Pleased by your talent for manipulation, Asmodeus amplifies your skills. Once, when you fail at the Diplomacy check to make a significant or consequential Request, you can cast *suggestion* on the target of your Request, suggesting the same course of action. This is a divine innate spell.",
             "Moderate Boon": "Your eyes glow red like embers and your skin takes on a crimson tone. You gain darkvision and fire resistance 5.",
@@ -96,7 +100,12 @@
                 "6th:": "mislead"
             },
             "text": "Asmodeus is the First, the Dark Prince, the lord of darkness and law, and the ruler of the plane of Hell. If Asmodeus's own scriptures are to believed-and they are corroborated by certain other accounts, like the angel-penned *Book of the Damned*-he is one of the oldest beings of the multiverse. These texts claim that in time before time, in a world not yet created, Asmodeus and his brother Ihys were among the first gods in existence. During these unnamed ages, the two gods quarreled over the fate of the souls of their creations, and Asmodeus slew his brother. Confident that Ihys's act of granting mortals free will was folly, Asmodeus made his own convictions known: that existence is best served by absolute order and discipline. These claims contradict other popular creation myths, and both theologians and immortal agents of the gods doubt Asmodeus's claims to varying degrees, but while there is no evidence to prove them, they are also difficult to refute.",
-            "divinterDesc": "Asmodeus tends to offer his gifts to entice those on the precipice of yielding to his vile temptations. His curses come most often in response to those who break contracts in his name, or commit other personal insults."
+            "divinterDesc": "Asmodeus tends to offer his gifts to entice those on the precipice of yielding to his vile temptations. His curses come most often in response to those who break contracts in his name, or commit other personal insults.",
+            "divAbility": [
+                [
+                    "any, though characters who commit themselves to Asmodeus this way have their souls bound to the Dark Prince for all eternity"
+                ]
+            ]
         },
         {
             "name": "Calistria",
@@ -122,7 +131,6 @@
             "Edicts": "pursue your personal freedom, seek hedonistic thrills, take revenge",
             "Anathema": "become too consumed by love or a need for revenge, let a slight go unanswered",
             "Areas of Concern": "lust, revenge, and trickery",
-            "Divine Ability": "Dexterity or Charisma",
             "divinterSource": "Gods & Magic pg. 17",
             "Minor Boon": "Calistria smiles on the riskiest deceptions. Once, when you roll a failure on a check to Lie, you get a critical success instead. Calistria typically grants this boon for an extremely consequential lie.",
             "Moderate Boon": "A foot-long wasp finds and befriends you. It serves you as a familiar as long as you maintain Calistria's grace. The wasp always has the burrower and flier familiar abilities.",
@@ -143,7 +151,13 @@
                 "6th:": "mislead"
             },
             "text": "As symbolized by the three daggers of her religious symbol, Calistria has three aspects: lust, revenge, and trickery. Silver-tongued and charming, she is a master of weaving insults into compliments and laying intricate groundwork for retribution at its finest. She is a goddess of vengeance, but it would be a mistake to assume that means she pursues justice. Calistria is fickle, shifting her loyalties and interests as her whims take her-though she never forgets a slight, and any who think she has forgiven will surely find it is only a matter of time before they are targeted by a long-term plot of revenge to lay them thoroughly low.",
-            "divinterDesc": "Signs of favor or displeasure from the Savored Sting are sometimes subtle and at other times incontrovertible. Calistria typically grants her boon to those on the path toward great vengeance and curses those who slight her followers, particularly if those followers are sex workers, though her fickle heart rarely commits to any absolute guidelines."
+            "divinterDesc": "Signs of favor or displeasure from the Savored Sting are sometimes subtle and at other times incontrovertible. Calistria typically grants her boon to those on the path toward great vengeance and curses those who slight her followers, particularly if those followers are sex workers, though her fickle heart rarely commits to any absolute guidelines.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Cayden Cailean",
@@ -168,7 +182,6 @@
             "Edicts": "drink, free slaves and aid the oppressed, seek glory and adventure",
             "Anathema": "waste alcohol, be mean or standoffish when drunk, own a slave",
             "Areas of Concern": "ale, bravery, freedom, and wine",
-            "Divine Ability": "Constitution or Charisma",
             "divinterSource": "Gods & Magic pg. 19",
             "Minor Boon": "Cayden Cailean helps you recover from nights of carousing. While you still get drunk and otherwise experience the effects of alcohol normally, you are never hung over the next morning.",
             "Moderate Boon": "You share some of the bravery Cayden espoused during his ascension. When you roll a success on a saving throw against a fear effect, you get a critical success instead. If you have the fighter bravery class feature, when you roll a critical failure on a save against a fear effect, you get a failure instead.",
@@ -189,7 +202,13 @@
                 "5th:": "hallucination"
             },
             "text": "Once a mortal human, Cayden Cailean is now one the few deities known as the Ascended. In his mortal years, Cayden was a sellsword of no small fame, known for his boisterous manner, skill with a blade, and fearless resolve. During a particularly rowdy night of drinking, a series of escalating dares led the wandering mercenary to attempt the Test of the Starstone. He emerged from the Starstone Cathedral 3 days later, laughing, a fully realized god. Divine responsibility did little to change Cayden's attitude from what it was in his mortal life. He continues to crave adventure, drink, and pleasurable company while abhorring bullies, tyrants, and cowards.",
-            "divinterDesc": "Cayden sometimes hands out his blessings and communicates his ire at seemingly random opportunities based on his drunken whims. In particular, Cayden blesses the recently liberated to help secure their freedom. Cayden is also known to grant particularly trivial and harmless curses to those who disrupt revelry. These curses typically cause the disruptor to change in appearance, taking on a comical or farcical look. He is quick to lift these curses by dawn or for those who give in to the enjoyment of the evening and join the festivities."
+            "divinterDesc": "Cayden sometimes hands out his blessings and communicates his ire at seemingly random opportunities based on his drunken whims. In particular, Cayden blesses the recently liberated to help secure their freedom. Cayden is also known to grant particularly trivial and harmless curses to those who disrupt revelry. These curses typically cause the disruptor to change in appearance, taking on a comical or farcical look. He is quick to lift these curses by dawn or for those who give in to the enjoyment of the evening and join the festivities.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Desna",
@@ -214,7 +233,6 @@
             "Edicts": "aid fellow travelers, explore new places, express yourself through art and song, find what life has to offer",
             "Anathema": "cause fear or despair, cast nightmare or use similar magic to corrupt dreams, engage in bigoted behavior",
             "Areas of Concern": "dreams, luck, stars, and travelers",
-            "Divine Ability": "Dexterity or Charisma",
             "divinterSource": "Gods & Magic pg. 21",
             "Minor Boon": "For those at the end of a journey, Desna gifts a deep sleep. Once, after you rest, you completely recover all Hit Points, remove all negative conditions, and become free of any curses or diseases.",
             "Moderate Boon": "Desna twists fortune in your favor. Once per day, after determining the result of a check, you can reroll the check and take the new result.",
@@ -238,7 +256,13 @@
                 "5th:": "dreaming potential"
             },
             "text": "The night didn't know beauty until Desna came into existence. While the other gods toiled away to create the world, she set her sights on the heavens, placing each star in the sky. After surveying her artistry, she hung the brightest star high in the north and made it her home. Her first gift to mortals was this beacon of hope, a twinkling sign in the dark sky that they could turn to when lost or unsure of themselves. Desna provides safe passage through the darkness to all, should they choose to follow.",
-            "divinterDesc": "Desna favors those who follow their hearts and whims without bringing harm to others."
+            "divinterDesc": "Desna favors those who follow their hearts and whims without bringing harm to others.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Erastil",
@@ -263,7 +287,6 @@
             "Edicts": "care for your home and family, fulfill your duties, keep the peace, protect the community",
             "Anathema": "abandon your home in its time of need, choose yourself over your community, tarnish your reputation, tell lies",
             "Areas of Concern": "family, farming, hunting, and trade",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 23",
             "Minor Boon": "Erastil shares in his bounty as long as you work for it. Whenever you roll a critical failure at a check to Subsist in the wild, you get a failure instead.",
             "Moderate Boon": "You share Erastil's sharp eye, allowing you to use a longbow in any situation. When you attack with a longbow, you can ignore the longbow's volley trait, and longbows have double the normal range increment for you.",
@@ -286,7 +309,13 @@
                 "5th:": "tree stride"
             },
             "text": "Unlike many other good deities, Erastil does not send his followers out into the world to fight and crush evil. Eschewing crusades and other ventures that take his followers away from their homes, Erastil watches over those who devote their lives to family and community. He is primarily an agricultural deity, specifically focusing on those aspects of nature that either can be tamed or are of use to his followers. His domain encompasses the plants and animals that farmers, hunters, and ranchers deal with in their everyday lives. While he is a protective deity, Erastil steps in only when quiet, pastoral lives are threatened. He desires his followers to live their lives in peace, with no risk of being conscripted into armies, devoured by monsters, or destroyed by magic.",
-            "divinterDesc": "Erastil favors those who commit themselves to their communities and detests those who disrupt these families."
+            "divinterDesc": "Erastil favors those who commit themselves to their communities and detests those who disrupt these families.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Gorum",
@@ -311,7 +340,6 @@
             "Edicts": "attain victory in fair combat, push your limits, wear armor in combat",
             "Anathema": "kill prisoners or surrendering foes, prevent conflict through negotiation, win a battle through underhanded tactics or indirect magic",
             "Areas of Concern": "battle, strength, and weapons",
-            "Divine Ability": "Strength or Constitution",
             "divinterSource": "Gods & Magic pg. 25",
             "Minor Boon": "Gorum grants you a weapon whenever you need one. You can use an Interact action to draw a 0-level non-magical iron weapon, even if you have no weapons on your person. Such a weapon lasts only as long as you continue using it to attack, and it can't be sold, given away, melted for scrap iron, or the like.",
             "Moderate Boon": "Your blows become unstoppable, carrying the momentum of Gorum's thrill for battle. Your greatsword Strikes gain the forceful trait.",
@@ -332,7 +360,13 @@
                 "4th:": "weapon storm"
             },
             "text": "The clash of steel, the cry of victory, the gasping denial of death: these are the sound of prayers to Our Lord in Iron, for to follow Gorum is to fight. Gorum does not care the reason for battle-a village's desperate stand against raiders is no less worthwhile to him than a crusader army marching against demons in the Sarkoris Scar-nor does he choose sides in such clashes. Good or evil, law or chaos, the reason for the fight is irrelevant. It is the thrill of battle that finds his favor, the crucible of struggle in which victory is there for the taking.",
-            "divinterDesc": "Gorum views things very simply: one either fights and earns his favor, or one is a coward and receives only scorn."
+            "divinterDesc": "Gorum views things very simply: one either fights and earns his favor, or one is a coward and receives only scorn.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Gozreh",
@@ -359,7 +393,6 @@
             "Edicts": "cherish, protect, and respect nature in all its forms",
             "Anathema": "bring civilization to intrude on the wild, create undead, despoil areas of natural beauty",
             "Areas of Concern": "nature, the sea, and weather",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 27",
             "Minor Boon": "Gozreh grants their guidance while at sea. You are under the constant effects of *know direction* and become trained in Sailing Lore (or another Lore skill if you are already trained in Sailing Lore).",
             "Moderate Boon": "You gain the touch of the sea. You can breathe underwater and gain a swim Speed equal to your land Speed.",
@@ -383,7 +416,13 @@
                 "5th:": "control water"
             },
             "text": "A timeless entity birthed from the first wind to stir the vast oceans, Gozreh wanders the world in the air and the seas. Sailors drop boxes of cargo as offerings to avoid a fatal storm, hoping to please the Wind and the Waves, even though they know that such pleas are far more likely to go unnoticed as they are to draw their deity's attention. The deity's temperament is fickle and their fury swift, hurling bolts of lightning and dragging to the crushing depths those who dare befoul the natural world. Gozreh is the sea that encapsulates the land and the wind that moves its surface, the birds that traverse the sky and the clouds that shield them.",
-            "divinterDesc": "Gozreh is pleased when their creatures and waterways are treated with respect but quick to show their displeasure."
+            "divinterDesc": "Gozreh is pleased when their creatures and waterways are treated with respect but quick to show their displeasure.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Iomedae",
@@ -407,7 +446,6 @@
             "Edicts": "be temperate, fight for justice and honor, hold valor in your heart",
             "Anathema": "abandon a companion in need, dishonor yourself, refuse a challenge from an equal",
             "Areas of Concern": "honor, justice, rulership, and valor",
-            "Divine Ability": "Strength or Constitution",
             "divinterSource": "Gods & Magic pg. 29",
             "Minor Boon": "You always present yourself at your best. Your clothing and person are always clean and unrumpled, the metal of your blade and armor shining and unblemished. This doesn't prevent you from being exposed to diseases and other afflictions via filth, but it protects you as well as if you had washed thoroughly right away.",
             "Moderate Boon": "Your heart beats with a determined valor. Once, Iomedae ends all negative effects affecting you, unless they are from an artifact, deity, or similarly powerful source; she also restores all lost Hit Points and replenishes your spells, Focus Points, and other daily resources.",
@@ -430,7 +468,13 @@
                 "4th:": "fire shield"
             },
             "text": "Iomedae, the youngest among the prominent deities of the Inner Sea region, had already proven herself worthy of divinity before her ascension. Born in Cheliax, she followed the path of the sword and fought evil, eventually becoming a paladin of Aroden's herald Arazni. She became a legend among the Shining Crusade, leading the Knights of Ozem in a series of victories over the Whispering Tyrant. Iomedae became the third known mortal to pass the Test of the Starstone when she ascended to divinity in 3832 AR. As Arazni had been slain during the Shining Crusade, Aroden elevated the newly ascended goddess to be his new herald. When Aroden himself died, Iomedae inherited most of his worshippers and became a major deity of honor and justice.",
-            "divinterDesc": "Iomedae grants her blessings to those who show valor in trying times."
+            "divinterDesc": "Iomedae grants her blessings to those who show valor in trying times.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Irori",
@@ -456,7 +500,6 @@
             "Edicts": "be humble; help others perfect themselves; hone your body, mind, and spirit to a more perfect state; practice discipline",
             "Anathema": "become addicted to a substance, destroy an important historical text, repeatedly fail to maintain self-control",
             "Areas of Concern": "history, knowledge, and self-perfection",
-            "Divine Ability": "Intelligence or Wisdom",
             "divinterSource": "Gods & Magic pg. 31",
             "Minor Boon": "Irori grants you great insight and knowledge. Once, when you roll a failure at a check to Recall Knowledge, you get a critical success instead. Furthermore, the check loses the secret trait, so you know for sure that the result was a critical success. Irori typically grants this boon for an extremely consequential check to Recall Knowledge.",
             "Moderate Boon": "Your body rebuilds after adversity, becoming stronger. You can cast *wholeness of body* as an occult ki spell. If you didn't have one already, you gain a focus pool with 1 Focus Point and are trained in occult spell attack rolls and spell DCs (the sidebar on the",
@@ -476,7 +519,13 @@
                 "4th:": "stoneskin"
             },
             "text": "Irori exemplifies the concepts of self-perfection. His dogma states that he was a mortal who gained godhood through achieving a physical and mental state that surpassed mortal limitations. His followers seek to emulate their god's divine state by perfecting themselves using the words of the *Unbinding of Fetters*, Irori's sacred text. The illuminated pages of the tome detail numerous physical, spiritual, and mental exercises, as well as methods of learning and remembering.",
-            "divinterDesc": "Irori grants his boons to those making progress on their paths toward perfection. He avoids bestowing misfortune as punishment, preferring to do so only to give an individual a challenging obstacle to overcome to help them progress in their quest for self-perfection."
+            "divinterDesc": "Irori grants his boons to those making progress on their paths toward perfection. He avoids bestowing misfortune as punishment, preferring to do so only to give an individual a challenging obstacle to overcome to help them progress in their quest for self-perfection.",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Lamashtu",
@@ -500,7 +549,6 @@
             "Edicts": "bring power to outcasts and the downtrodden, indoctrinate children in Lamashtu's teachings, make the beautiful monstrous, reveal the corruption and flaws in all things",
             "Anathema": "attempt to treat a mental illness or deformity, provide succor to Lamashtu's enemies",
             "Areas of Concern": "aberrance, monsters, and nightmares",
-            "Divine Ability": "Constitution or Strength",
             "divinterSource": "Gods & Magic pg. 33",
             "Minor Boon": "Lamashtu's touch mutates a part of your body. You gain either an unarmed Strike that deals 1d6 damage or one that deals 1d4 damage and has the finesse and agile traits. Whether the attack deals bludgeoning, slashing, or piercing damage depends on the mutation. If the unarmed Strike replaces a limb, you can still use the mutated limb for its original functions. Lamashtu chooses the form and function of your mutation.",
             "Moderate Boon": "You spread Lamashtu's nightmares everywhere you go. You can cast *confusion* once per day as an divine innate spell.",
@@ -523,7 +571,13 @@
                 "4th:": "nightmare"
             },
             "text": "For those who revel in the corruption of the pure or who find themselves spurned and neglected by a world that despises their differences, Lamashtu offers respite among her grotesque brood. The Mother of Monsters readily accepts mortals into her fold and has made it her goal to twist mortal life toward her abhorrent ideals. Her intervention is widely known to inflict corruptions and terrible nightmares. Ostracized individuals who share her ideals will find this intervention a boon, while others treat similar events as horrible curses.",
-            "divinterDesc": "Lamashtu rewards kinship with monsters and brutal dominance in combat. Those who offend her serve the brood as prey or unwilling sacrifices."
+            "divinterDesc": "Lamashtu rewards kinship with monsters and brutal dominance in combat. Those who offend her serve the brood as prey or unwilling sacrifices.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Strength"
+                ]
+            ]
         },
         {
             "name": "Nethys",
@@ -551,7 +605,6 @@
             "Edicts": "seek out magical power and use it",
             "Anathema": "pursue mundane paths over magical ones",
             "Areas of Concern": "magic",
-            "Divine Ability": "Wisdom or Intelligence",
             "divinterSource": "Gods & Magic pg. 35",
             "Minor Boon": "Nethys casts a powerful spell to help you in a pinch. Once, Nethys casts a spell 1 level higher than the highest-level spell you can cast. If you can't cast spells, Nethys casts a 1st-level spell to help you.",
             "Moderate Boon": "Nethys grants you insight into the secrets of magic. Add one spell from a different tradition of magic to your spell list. You still must learn it or add it to your repertoire normally.",
@@ -580,7 +633,13 @@
                 "9th:": "disjunction"
             },
             "text": "To some, magic is a powerful weapon. To others, it's a malleable tool. And to a few, it's a source of purpose. With an understanding of spellcasting, creatures can cause fire to erupt from their hands, call otherworldly beings to aid them, bewitch the senses, and even bring the dead back to life. The ability to reshape reality to better suit one's needs and desires is a powerful call that most only dream of being able to answer, and few are ever able to truly master such might. One such master was Nethys, who was revered as a god-king in ancient Osirion. Having sought to unlock all of the secrets and potential held within the planes and beyond, Nethys shattered his own mind from the sheer overload of knowledge to which he was exposed. Witnessing all of creation, the secrets of the universe, and the vast expanse of what has been seen and will be seen rent his mind in the same moment he elevated to the status of a god. Nethys gained unlimited power and the skill to utilize it, but at the cost of his core self and mental security. This resulted in a split soul, two sides warring within the same body. One seeks to destroy the world, to purge it through fire and ruin, and to conquer all that exists. The other attempts to protect the world, to elevate and educate, and to release it from its limits.",
-            "divinterDesc": "Nethys is often impartial to his followers and their wishes, so it is rare to gain a heightened favor from the god of magic. However, blatant disregard and stifling of magic will certainly earn his ire."
+            "divinterDesc": "Nethys is often impartial to his followers and their wishes, so it is rare to gain a heightened favor from the god of magic. However, blatant disregard and stifling of magic will certainly earn his ire.",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Norgorber",
@@ -606,7 +665,6 @@
             "Edicts": "keep your true identity secret, sacrifice anyone necessary, take every advantage in a fight, work from the shadows",
             "Anathema": "allow your true identity to be connected to your dark dealings, share a secret freely, show mercy",
             "Areas of Concern": "greed, murder, poison, secrets",
-            "Divine Ability": "Dexterity or Intelligence",
             "divinterSource": "Gods & Magic pg. 37",
             "Minor Boon": "Norgorber protects your secrets and lies. Once, when you roll a failure at a Deception check to tell a Lie, you get a critical success instead. Norgorber typically chooses to grant this boon to protect an extremely consequential lie.",
             "Moderate Boon": "Your poisons are everlasting. If your Strike with a poisoned weapon critically fails, or succeeds but fails to deal slashing or piercing damage, the poison is not spent. The poison is still spent once successfully applied to a creature.",
@@ -627,7 +685,13 @@
                 "4th:": "phantasmal killer"
             },
             "text": "Norgorber is the most mysterious of the Ascended, the group of mortals who assumed godhood after passing the Test of the Starstone. Unlike Iomedae's and Cayden Cailean's mortal existences, Norgorber's life before his ascension is a mystery; the god himself has shrouded details of his mortal life in secrecy. This is no surprise to those familiar with Norgorber-he is the master of all secrets, a calculating manipulator who cleverly and ruthlessly wields the power of hidden knowledge to achieve his own ends. Only his most trusted worshippers know enough about his goals to assist in the god's plans, and even those worshippers often have their memories modified after their parts in Norgorber's schemes are complete.",
-            "divinterDesc": "Norgorber's favor and displeasure are subtle, yet powerful."
+            "divinterDesc": "Norgorber's favor and displeasure are subtle, yet powerful.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Pharasma",
@@ -652,7 +716,6 @@
             "Edicts": "strive to understand ancient prophecies, destroy undead, lay bodies to rest",
             "Anathema": "create undead, desecrate a corpse, rob a tomb",
             "Areas of Concern": "birth, death, fate, prophecy, and time",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 39",
             "Minor Boon": "You see a momentary, prophetic glimpse of your fate. Once, you gain a +2 status bonus to a single check; you can apply this bonus after you determine the result, and it can potentially change the degree of success.",
             "Moderate Boon": "You gain a greater mastery over the energies of life and death. Your Strikes deal 1 positive damage to undead. Your spells that deal positive damage to undead gain a +1 status bonus to damage per spell level, and your spells that heal the living gain a +1 status bonus to the Hit Points restored per spell level.",
@@ -677,7 +740,13 @@
                 "4th:": "phantasmal killer"
             },
             "text": "No record of history, and not even other gods, can recall a time before Pharasma. Her throne lies within a vast, gothic cathedral located on the infinite Spire at the center of the planes. From here, she looks both forward and backward in time, observing the births, lives, and deaths of every soul, as she serves as the final arbiter of a soul's destination after death. Psychopomp servants of Pharasma guide and safeguard newly dead souls along the River of Souls to her realm, where she judges each soul and ensures it is sent to the proper plane for its afterlife, according to its alignment and mortal deeds. Although she can see all possible fates and knows the fate of each individual, free will and choice can alter a soul's final destination, and she places great weight on the individual's actions and personal choices. Therefore, Pharasma withholds her final judgment until a soul stands before her. Her prophecies are cryptic, and their full meanings are rarely revealed until the foretold events occur.",
-            "divinterDesc": "Those who would prevent a soul from reaching the afterlife draw Pharasma's ire, but those who merely dabble in pursuits like lengthening their life or resurrection are usually ignored, as eventually death comes for all."
+            "divinterDesc": "Those who would prevent a soul from reaching the afterlife draw Pharasma's ire, but those who merely dabble in pursuits like lengthening their life or resurrection are usually ignored, as eventually death comes for all.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Rovagug",
@@ -701,7 +770,6 @@
             "Edicts": "destroy all things, free Rovagug from his prison",
             "Anathema": "create something new, let material ties restrain you, torture a victim or otherwise delay its destruction",
             "Areas of Concern": "destruction, disaster, and wrath",
-            "Divine Ability": "Strength or Constitution",
             "divinterSource": "Gods & Magic pg. 41",
             "Minor Boon": "Your attack becomes more destructive. Once, one of your failed or successful attacks becomes a critical hit, and your weapon or unarmed attack gains the deadly d12 trait for this attack, replacing any deadly trait it already had. Rovagug typically grants this boon when the critical hit could destroy something precious or significant.",
             "Moderate Boon": "You can devour all. You mouth grows into a horrible circular, insectile maw of needle-like teeth. You gain a bite unarmed attack that deals 1d8 piercing damage. Additionally, you can stomach eating anything you can fit down your throat-even rocks or small objects. You gain a +4 status bonus to saves resulting from eating something, such as diseases, poisons, or other effects of the ingested object. This doesn't allow you to digest magic items that would otherwise be difficult or impossible to destroy, such as cursed items or artifacts.",
@@ -725,7 +793,13 @@
                 "6th:": "disintegrate"
             },
             "text": "Rovagug has no single holy scripture. He has little use for one, for his sole commandment is to destroy, and his followers need no instruction in how to accomplish that. The figurative and literal monsters who worship Rovagug share their myths and legends in secret shrines and hidden caves, calling him the Rough Beast, the Imprisoned King, the Tide of Fangs, the Unmaker, and the Worldbreaker. They tell each other that each life they snuff out, each piece of art they destroy, each work of labor they bring tumbling down puts a crack in the prison that holds their god. Each of their little efforts of destruction adds up and will one day free him, setting him loose to bring about the end of all things.",
-            "divinterDesc": "Rovagug's imprisonment means he can almost never intercede on Golarion, but some places lead far enough into the earth that the god's profane influence can leak through. He is as likely to curse those who draw his attention as he is to reward them, though great enough acts of violence and destruction may earn his favor."
+            "divinterDesc": "Rovagug's imprisonment means he can almost never intercede on Golarion, but some places lead far enough into the earth that the god's profane influence can leak through. He is as likely to curse those who draw his attention as he is to reward them, though great enough acts of violence and destruction may earn his favor.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Sarenrae",
@@ -750,7 +824,6 @@
             "Edicts": "destroy the Spawn of Rovagug, protect allies, provide aid to the sick and wounded, seek and allow redemption",
             "Anathema": "create undead, lie, deny a repentant creature an opportunity for redemption, fail to strike down evil",
             "Areas of Concern": "healing, honesty, redemption, and the sun",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 43",
             "Minor Boon": "Your healing hands are blessed with a warm flame. Once, when you heal another creature, instead of healing it for the normal amount, you heal the creature to full Hit Points, no matter how much damage it has taken. Sarenrae typically grants this boon in extremely consequential circumstances.",
             "Moderate Boon": "Your blade burns the irredeemable. Your attacks deal an additional 1d6 fire damage that ignores fire resistance.",
@@ -773,7 +846,13 @@
                 "4th:": "wall of fire"
             },
             "text": "Sarenrae is one of the most popular deities on Golarion by virtue of her association with the life-giving sun and her perpetual offer to help anyone be their best, even when they have made mistakes. Most people thank her for her kind work to channel the sun's power for everyone's safety and livelihood, and thank her clergy for granting her healing power to all who need it. Mortals look to the Dawnflower as an example of boundless love, exquisite kindness, and true patience. They pray to her to heal the sick, lift up the downtrodden, and illuminate darkness of circumstance as well as darkness of spirit. Her followers aspire to emulate her through generosity, nurturing, truthfulness, and selfless courage. They oppose evil everywhere with words first, and when necessary, with scimitar and flame.",
-            "divinterDesc": "Sarenrae often bestows boons for making a sacrifice to do better or taking a risk to redeem another. She typically curses those who betray her mercy."
+            "divinterDesc": "Sarenrae often bestows boons for making a sacrifice to do better or taking a risk to redeem another. She typically curses those who betray her mercy.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Shelyn",
@@ -798,7 +877,6 @@
             "Edicts": "be peaceful, choose and perfect an art, lead by example, see the beauty in all things",
             "Anathema": "destroy art or allow it to be destroyed, unless saving a life or pursuing greater art; refuse to accept surrender",
             "Areas of Concern": "art, beauty, love, and music",
-            "Divine Ability": "Wisdom or Charisma",
             "Divine Skill": "or",
             "divinterSource": "Gods & Magic pg. 45",
             "Minor Boon": "Once, when you roll a failure on a Diplomacy check, you get a critical success instead. Shelyn typically grants this boon only when the Diplomacy check would serve to increase love or offer a chance of redemption.",
@@ -822,7 +900,13 @@
                 "4th:": "creation"
             },
             "text": "Shelyn watches over existence with a kind and loving eye, encouraging mortals to make the best of their lives by spreading love, art, and beauty as best they can. Even the crudest artistic awakenings are worthy of praise in the goddess's eyes, as they represent an individual's expression of life's trials and triumphs. She believes every creature is worthy of love and capable of creating art in their own way. Shelyn's religion does not require chastity, fidelity, or a particular relationship structure, as the passion of early romance is a facet of love just as important and valid as the comfortable trust between a long-married couple. However, she does make the distinction between courtship and pure carnal desire, and she prefers that trysts blossom into more meaningful relationships along the way.",
-            "divinterDesc": "When creatures perform pleasing acts, such as spreading beauty, or displeasing actions, such as betraying loved ones, Shelyn may respond accordingly."
+            "divinterDesc": "When creatures perform pleasing acts, such as spreading beauty, or displeasing actions, such as betraying loved ones, Shelyn may respond accordingly.",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Torag",
@@ -846,7 +930,6 @@
             "Edicts": "be honorable and forthright, keep your word, respect the forge, serve your people",
             "Anathema": "tell lies or cheat someone, intentionally create inferior works, show mercy to the enemies of your people",
             "Areas of Concern": "forge, protection, and strategy",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 47",
             "Minor Boon": "Torag repairs your equipment so you may continue your vigil. Once, a shield, weapon, or other item you hold or are wearing recovers all of its Hit Points. The item's Hardness doubles for 1 minute. Torag can grant this boon just as the item would have been destroyed, preventing the item's destruction. Occasionally, he grants this boon to restore an item important to dwarven history that has already been fully destroyed.",
             "Moderate Boon": "You are counted as family among Torag and his followers. You gain the effects of a single dwarf ancestry feat of Torag's choice, even if you are not a dwarf, as long as you maintain Torag's blessing.",
@@ -869,7 +952,13 @@
                 "4th:": "creation"
             },
             "text": "The head of the dwarven pantheon is the most visible of the dwarven deities, to the extent that Torag is the only dwarven deity most non-dwarves know of. While the other dwarven gods represent specific areas of dwarven life and culture, thus forming an expansive and comprehensive dwarven pantheon, Torag's areas of concern are those most central to dwarven society. In his own family, Torag models the values of community and protection that have cemented deep-rooted relationships among dwarven clans. His focus on strategy and tactical acumen centers on protection, reflected in dwarves' impenetrable fortresses and conservative military tactics, including their willingness to use offensive maneuvers as a form of defense. He also represents the forge: the creation of fine works from raw materials, practice and mastery of a craft, and pride in one's work. His purview extends even to those activities that feed the forge and dwarven artisanship, such as mining the earth for raw ore and gemstones. Torag's oversight over these core concepts has secured his place at the head of the dwarven pantheon for ages. It was Torag who sent the dwarves on their legendary Quest for Sky during the Age of Darkness, and his worship was long-established even then. Indeed, among dwarves, Torag is often called the Father of Creation.",
-            "divinterDesc": "Torag makes his pleasure or displeasure known through unsubtle signs."
+            "divinterDesc": "Torag makes his pleasure or displeasure known through unsubtle signs.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Urgathoa",
@@ -894,7 +983,6 @@
             "Edicts": "become undead upon death, create or protect the undead, sate your appetites",
             "Anathema": "deny your appetites, destroy undead, sacrifice your life",
             "Areas of Concern": "disease, gluttony, and undeath",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 49",
             "Minor Boon": "You feast on the spoils of life and death. You gain the benefits of the irongut goblin heritage, regardless of your ancestry. If you already have this heritage, the circumstance bonus increases to +4.",
             "Moderate Boon": "Urgathoa blesses you as one of her children. You gain negative healing.",
@@ -918,7 +1006,13 @@
                 "7th:": "mask of terror"
             },
             "text": "The chosen of Urgathoa do not dread the flaws of mortal flesh, such as aging, disease, or even death, for so long as they indulge in excess above all else, their goddess offers eternal freedom from such fickle constraints. Urgathoa herself was once a mortal woman who challenged and rejected the tenets of deities whose followers expected mindless conformity, temperance, and restraint. Why would the gods craft Golarion into a near-endless buffet abundant with pleasures of the body and mind if the living weren't destined to feast from it? Urgathoa so loved satiating her life's appetites that in death, she spat in the face of Pharasma's judgment, murdered the psychopomp assigned to aid her transition to the afterlife, and tore herself from the Boneyard with a feat of will that not only returned her to the Material Plane but also transformed her into the first divine undead creature.",
-            "divinterDesc": "Urgathoa interferes in mortal affairs to fuel her own self-gratification and obsession with observing new sensations."
+            "divinterDesc": "Urgathoa interferes in mortal affairs to fuel her own self-gratification and obsession with observing new sensations.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Zon-Kuthon",
@@ -943,7 +1037,6 @@
             "Edicts": "bring pain to the world, mutilate your body",
             "Anathema": "create permanent or long-lasting sources of light, provide comfort to those who suffer",
             "Areas of Concern": "darkness, envy, loss, and pain",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic pg. 51",
             "Minor Boon": "The Midnight Lord turns your blood and pain into chains of midnight darkness to destroy your foes. Once, for 1 minute, whenever you take slashing, piercing, or bleed damage, chains rip forth from your body, affecting creatures in a line from your position in the direction of the attack (or in the direction of your choice for bleed damage or if you deal the damage yourself) with the effect of a *grim tendrils* spell whose level is equal to half your level rounded up, and whose DC is your highest spell DC (or 10 + your level + your Wisdom modifier if you have no spell DC).",
             "Moderate Boon": "Each morning, during your daily preparations, scars gather into words on your flesh. The scars function as a scroll of a divine spell of Zon- Kuthon's choosing. After you use the scroll or receive magical healing, the boon fades for the day, though some or all of the scars might remain as a reminder.",
@@ -966,7 +1059,13 @@
                 "5th:": "shadow walk"
             },
             "text": "The Midnight Lord embodies and glorifies pain, shadows, and mutilation, and he is one of the most twisted and malevolent gods on the face of Golarion. Once known as Dou-Bral, he crafted the immense Star Towers that still help keep Rovagug pinned in his prison at Golarion's heart, lending his own skill and ability to the great deific alliance to bind that evil entity. Yet a divine argument between him and his sister Shelyn resulted in the god departing for parts unknown. Zon-Kuthon traveled beyond the edges of the multiverse and stared into the face of the incomprehensible things that dwell there. No one knows what he found in that place, but he returned-changed, but claiming to be strengthened by what he had endured. Likewise, the nation of Nidal on Golarion, which is bound to him, is a nation of survivors, founded by those few strong enough to do what they must so their people could survive the terrible aftermath of Earthfall and the Age of Darkness that followed.",
-            "divinterDesc": "Zon-Kuthon rarely intervenes directly in mortal affairs, but when he does take a personal interest in a creature, the effect is as terrible as the god himself."
+            "divinterDesc": "Zon-Kuthon rarely intervenes directly in mortal affairs, but when he does take a personal interest in a creature, the effect is as terrible as the god himself.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Achaekek",
@@ -991,7 +1090,6 @@
             "Edicts": "conduct assassinations, spread the Red Mantis's infamy, wield sawtooth sabers in combat",
             "Anathema": "kill a rightful ruler, become fixated on petty matters such as others' gender or ancestry, abandon an assassination contract you agreed to pursue",
             "Areas of Concern": "assassins, divine punishments, and the Red Mantis",
-            "Divine Ability": "Strength or Dexterity",
             "divinterSource": "Gods & Magic - Web Supplement pg. 3",
             "Minor Boon": "You hide among the shadows of death. Once, when you would fail a Stealth check, you critically succeed instead. Achaekek typically grants this boon for an extremely consequential Stealth check that could lead to an assassination, such as one that could get you into position to kill an important target, but rarely on a Stealth check to help you escape.",
             "Moderate Boon": "You gain the god's approval to take a life. You can cast *death knell* once per day as an innate divine spell.",
@@ -1012,7 +1110,13 @@
                 "4th:": "phantasmal killer"
             },
             "text": "While Achaekek's divine genesis is heavily debated among scholars, it is believed that he was created-either by the power of a singular deity or a group of them-to eradicate those who would steal a god's divinity, and he has since become the enforcer of divine punishment. Known as He Who Walks in Blood, he slumbers in the blood of heretics and worshippers alike in an immense cleft carved into the base of the Boneyard's spire, a realm known as the Blood Vale. He keeps no formal relationships with any other deities, even his sister, Grandmother Spider, who repeatedly coaxes Achaekek to rebel against the gods and abandon his duties. In response, even though some gods disapprove of Achaekek's methods, few openly defy him.",
-            "divinterDesc": "He Who Walks in Blood detests oathbreakers and bears a particular prejudice against mortals seeking to ascend into divinity, but the Mantis God believes in compensation for selfless duties and rewards the rare individual for their murderous deeds. Violation of his tenets and, occasionally, slights against Grandmother Spider may provoke Achaekek's wrath."
+            "divinterDesc": "He Who Walks in Blood detests oathbreakers and bears a particular prejudice against mortals seeking to ascend into divinity, but the Mantis God believes in compensation for selfless duties and rewards the rare individual for their murderous deeds. Violation of his tenets and, occasionally, slights against Grandmother Spider may provoke Achaekek's wrath.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Alseta",
@@ -1037,7 +1141,6 @@
             "Edicts": "offer to protect passageways and guide others through transitions, treat all other beings with courtesy and respect",
             "Anathema": "destroy a door or block a path for personal gain, stop a transition without good reason",
             "Areas of Concern": "doors, portals, thresholds, traditions",
-            "Divine Ability": "Intelligence or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 3",
             "Minor Boon": "Alseta's guiding hand aids your journeys. Once, when employing teleportation magic, you appear exactly on target, even if you used a notoriously imprecise spell like *plane shift*. Alseta typically grants this boon for extremely consequential magical travel, especially when time is of the essence.",
             "Moderate Boon": "New doors open themselves for you. You can cast *knock* once per day as a divine innate spell.",
@@ -1058,7 +1161,13 @@
                 "4th:": "dimension door"
             },
             "text": "Alseta holds sway over transitions. Physical transitions through doorways and portals or over thresholds, metaphorical transitions, and even the forward flow of time-Alseta influences them all. She watches over city gates, helping keep invaders out and defenders safe. She also watches over those moving into a new stage in life, whether that means a birthday, a marriage, or a more fitting body. It is common for anyone entering into a life change, such as moving to a new town or changing careers, to look to Alseta for guidance. Likewise, birth and death are both transitions, and expectant mothers and the bereaved both offer her prayers, linking Alseta's church to that of Pharasma. Some consider Alseta to be the goddess of teleportation, though she does not officially claim that title. She is also a popular god among some elven nations and cultures, who frequently associate Alseta with the *aiudara*, or elf gates, around Golarion.",
-            "divinterDesc": "The Welcomer is a patient goddess that rewards her followers. Incurring her wrath through discourtesy, lack of respect or intentionally making doors unpassable for any reason other than preventing harm can lead to reprimands that range from annoying to frustrating."
+            "divinterDesc": "The Welcomer is a patient goddess that rewards her followers. Incurring her wrath through discourtesy, lack of respect or intentionally making doors unpassable for any reason other than preventing harm can lead to reprimands that range from annoying to frustrating.",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Apsu",
@@ -1081,7 +1190,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Seek and destroy evil, travel the world, help others fend for themselves",
             "Anathema": "Fail to pursue a foe who has betrayed your mercy, attack a creature without certainty of wrongdoing",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "creation",
                 "protection",
@@ -1095,7 +1203,13 @@
                 "6th:": "dragon form (metallic dragons only)"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Arazni",
@@ -1122,7 +1236,6 @@
             "Edicts": "act with dignity, do whatever it takes to survive, despise and never forgive those who have hurt you",
             "Anathema": "create unwilling undead, insult Arazni",
             "Areas of Concern": "abused, dignity, unwilling undeath",
-            "Divine Ability": "Constitution or Intelligence",
             "divinterSource": "Gods & Magic - Web Supplement pg. 3",
             "Minor Boon": "Once, when you fail a saving throw against an effect that would compel you to take some action against your will, you critically succeed instead. Arazni typically grants this boon for consequential actions or particularly egregious violations of free will.",
             "Moderate Boon": "Blood from your wounds forms into armor or a piece of equipment you need. If what you need most is information, the blood forms letters spelling out that information.",
@@ -1145,7 +1258,13 @@
                 "6th:": "feeblemind"
             },
             "text": "More than anything, Arazni is a survivor. Once, long ago, she was a force for good, a warrior-mage who sought to improve the quality of life for residents of her homeland. Long after her mortal death, she returned as a herald of the god Aroden and fought alongside mortals during one of their darkest hours. But humanity and her patron alike abandoned her-first to the Whispering Tyrant, then to the necromancer Geb-and the torments she endured because of it changed her deeply. Still she survived, her broken body reanimated against her will as a powerful undead monstrosity. For over a millennium she was held captive as the lich queen of the undead nation of Geb, and her view of mortals, and humanity in particular, soured.",
-            "divinterDesc": "While the Unyielding has little regard for her followers, if suitably irritated or impressed, she might bestow the following banes or boons."
+            "divinterDesc": "While the Unyielding has little regard for her followers, if suitably irritated or impressed, she might bestow the following banes or boons.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Besmara",
@@ -1171,7 +1290,6 @@
             "Edicts": "sail the seas, stay loyal to captain and crew, take what you want",
             "Anathema": "betray shipmates, forsake piracy, settle on land",
             "Areas of Concern": "piracy, sea monsters, and strife",
-            "Divine Ability": "Dexterity or Constitution",
             "divinterSource": "Gods & Magic - Web Supplement pg. 4",
             "Minor Boon": "Besmara wants you to amuse her, placing both plunder and peril in your path. This intercession often takes the form of an unexpected treasure map, a message in a bottle, or some other sign leading you to a great reward, assuming you can handle the challenges along the way.",
             "Moderate Boon": "You are at home on the seas and always ready to plunder an enemy vessel or defend your own. When aboard a boat, you gain a +2 status bonus to all initiative rolls, Acrobatics checks to Balance, and Athletics checks to Climb. In addition, you never get seasick.",
@@ -1192,7 +1310,13 @@
                 "5th:": "mariner's curse"
             },
             "text": "Once nothing more than a powerful spirit of water with the ability to manipulate sea monsters, Besmara grew slowly in power over the centuries from sacrifices made by seafaring people. After defeating and consuming rival spirits of battle, gold, and wood, she became a minor god of piracy, strife, and sea monsters.Besmara, the Pirate Queen, cuts a brash and bold figure, as she often is depicted wearing buccaneer apparel consisting of loose-fitting, eye-catching clothing and black boots, and her hair is wind-tossed on even the calmest day. She and her followers adhere to a simple code of greed: take what you desire, no matter who it might belong to. Despite this, Besmara and her worshippers are generally loyal to one another, knowing that while on the waves raiding ships for treasure, a pirate crew can survive only if its members trust one another.",
-            "divinterDesc": "Due to her fiery temperament, the Pirate Queen is quick to punish or reward her followers, and is equally fast at rescinding her favor or forgiving transgressions."
+            "divinterDesc": "Due to her fiery temperament, the Pirate Queen is quick to punish or reward her followers, and is equally fast at rescinding her favor or forgiving transgressions.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Brigh",
@@ -1220,7 +1344,6 @@
             "Edicts": "craft new creations, pay attention to details, share achievements",
             "Anathema": "carelessly destroy others' creations or research, enslave intelligent constructs, abuse constructs, refuse to acknowledge or learn from mistakes",
             "Areas of Concern": "clockwork, invention, and time",
-            "Divine Ability": "Intelligence or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 4",
             "Minor Boon": "Knowledge floods your mind. Once, you can reroll a failed skill check to Recall Knowledge; you must use the second result, even if it's worse.",
             "Moderate Boon": "You become a wellspring of invention. You gain the Inventor feat, even if you don't meet its prerequisites, and when you roll a Crafting check for the Inventor feat, you use the result one degree of success better than the result you rolled.",
@@ -1243,7 +1366,13 @@
                 "7th:": "duplicate foe"
             },
             "text": "Brigh's exact origins are unknown, though her priests and various religious scholars have many theories on the matter. Some believe she was a construct who achieved consciousness and a spark of divinity, while others think she was a human alchemist and inventor who discovered ways to fuse mechanical components with her own physiology. Regardless of her origins, Brigh is a patient and thoughtful god who promotes unending curiosity and constant intellectual advancement. Her two most common forms are a humanoid woman made of bronze clockwork and a human woman wearing a bronze skullcap and armor composed of gears and other movable metal pieces. Though Brigh's usual demeanor is composed and reserved, she isn't an unfeeling automaton; she deeply cherishes the creations she and her followers make, and most of her worshippers feel the same way.",
-            "divinterDesc": "The Whisper in Bronze doesn't dole out punishments or rewards to her followers lightly."
+            "divinterDesc": "The Whisper in Bronze doesn't dole out punishments or rewards to her followers lightly.",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Casandalee",
@@ -1271,7 +1400,6 @@
             "Edicts": "advance the development of artificial intelligence, encourage understanding between artificial and organic life",
             "Anathema": "treat artificial life as lesser than organic life, foment distrust between artificial and organic life",
             "Areas of Concern": "artificial life, free thinking, intellectual apotheosis",
-            "Divine Ability": "Constitution or Intelligence",
             "divinterSource": "Gods & Magic - Web Supplement pg. 4",
             "Minor Boon": "Casandalee frees your thinking from dangerous control. Once, when you fail a Will save against an effect that would control your actions, you critically succeed instead. Casandalee typically grants this boon for particularly consequential violations of autonomy and agency.",
             "Moderate Boon": "Your organs are partially transformed into mechanical counterparts. You gain resistance 10 to negative damage, and the DC of your flat check to remove persistent bleed damage is only 5.",
@@ -1295,7 +1423,13 @@
                 "6th:": "wall of force"
             },
             "text": "Casandalee is an unusual god, one who achieved divinity through a merging of advanced science and faith. Formerly an artificial intelligence cloned from the mind of an android from outer space, Casandalee gained her godhood in the heart of Numeria within the computer core of a crashed spaceship, becoming the patron of artificial life, free thinking, and intellectual apotheosis.Though she is sometimes referred to as the Iron Goddess, Casandalee is much more than simple metal. She sometimes appears as a holographic reconstruction of her android form: a female humanoid with purple hair, blue lips, and pale skin traced with glowing circuitry, but upon close inspection, this image seems to consist of millions of complex algorithms of pure light. Casandalee and her followers seek to promote the advancement of Golarion's technology so that the world's inhabitants can better understand- and not fear-the complex mechanisms of so-called artificial life, including androids and free-willed artificial intelligences. Many androids consider themselves the chosen people of Casandalee and depict her as an obvious android with more circuitry or exposed components.",
-            "divinterDesc": "Seeing her android devotees and other followers of a constructed nature as her children, the Iron Goddess is most likely to bestow her boons and curses on these individuals."
+            "divinterDesc": "Seeing her android devotees and other followers of a constructed nature as her children, the Iron Goddess is most likely to bestow her boons and curses on these individuals.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Chaldira",
@@ -1320,7 +1454,6 @@
             "Edicts": "seek out and challenge oppressors and tyrants, defend friends and the innocent, engage in mischief that doesn't harm others",
             "Anathema": "suffer a bully's insults to you or another without retort, abandon a friend in need, attribute a lucky turn of events to your own skill",
             "Areas of Concern": "battle, fortune, mischief",
-            "Divine Ability": "Dexterity or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 5",
             "Minor Boon": "Once, you can choose the result of the next ordinary coin you flip or ordinary die you roll. If this ability is used for personal gain at the expense of someone innocent or less fortunate, Chaldira levies her moderate curse on you as punishment.",
             "Moderate Boon": "You gain a lucky impetuousness, allowing you to roll for initiative twice and use the higher result once per day. This is a fortune effect.",
@@ -1341,7 +1474,13 @@
                 "5th:": "cloak of colors"
             },
             "text": "Chaldira Zuzaristan, the Calamitous Turn, is a plucky, impulsive goddess venerated primarily by halflings. She embodies two aspects halflings see in themselves: a strong affinity for luck and bold determination to protect friends. Chaldira is hotheaded and cannot abide bullies in any form, and many of her worshippers are similarly impetuous, spoiling for any opportunity to leap fist-first at oppressors and tyrants. While many people consider this to be more of a vice than a virtue, Chaldira and her followers feel it is far better to run headlong into trouble than it is to meekly concede to evil out of fear or convenience. Chaldira is also the goddess of light-hearted mischief, insisting that harmless fun, even at others' expense, brings joy and strengthens ties within a community. While not all of Chaldira's followers are inveterate pranksters, most at least know some sleight-of-hand tricks. Chaldira is most often depicted as a halfling woman who matches the appearance of the local halfling community, with curly hair, freckles, and a patchwork red-and-green coat held together by several mismatched buttons.",
-            "divinterDesc": "The Calamitous Turn's pleasure most often manifests as improbably good luck, while her displeasure creates startling misfortune."
+            "divinterDesc": "The Calamitous Turn's pleasure most often manifests as improbably good luck, while her displeasure creates startling misfortune.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Dahak",
@@ -1364,7 +1503,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Kill metallic dragons, destroy things at your whim",
             "Anathema": "Spare a foe after you have chosen to kill them, forgive a slight",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "fire",
@@ -1378,7 +1516,13 @@
                 "6th:": "dragon form (chromatic dragons only)"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Erecura",
@@ -1403,7 +1547,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Manipulate dangerous beings and opportunities to your benefit, thrive in hostile conditions, divine the future",
             "Anathema": "Despoil nature, kill a natural plant or animal that has managed to thrive outside of its intended environment",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "fate",
                 "secrecy",
@@ -1417,7 +1560,13 @@
                 "3rd:": "nondetection"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Followers of Fate",
@@ -1452,11 +1601,12 @@
             "altDomains": [],
             "clericSpells": {
                 "1st:": "mindlink",
-                "2nd:": "web",
+                "3rd:": "threefold aspect",
                 "5th:": "prying eye"
             },
             "text": "On the Material Plane, some mortals worship norns as deities, while others, especially witches and bards, admire them as patrons or muses. Those who uphold norns as deities are known as Followers of Fate. Norns do little to discourage this veneration, but neither do they go out of their way to support such worship. Clerics who venerate norns might worship a specific norn or norn triumvirate, or all norns as a whole, but they gain the same benefits regardless of their choice. The religious symbol of Followers of Fate is a pair of shears cutting a golden thread, and their areas of concern are destiny, fate, and the aging process.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": []
         },
         {
             "name": "Gendowyn",
@@ -1481,7 +1631,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Preserve primal areas, destroy blighted fey and agents of Cyth V'sug, protect those who placate you with offerings",
             "Anathema": "Parley or make a deal with fiends, forgive those who deceive you, harm an innocent child",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "earth",
                 "family",
@@ -1495,7 +1644,13 @@
                 "5th:": "tree stride"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ghlaunder",
@@ -1519,7 +1674,6 @@
             "Edicts": "corrupt pieces of land, water sources, and communities; infect the weak; spread and nurture disease",
             "Anathema": "aid in ending a plague or infection, destroy something out of hand when you could have instead corrupted it or leeched off it first",
             "Areas of Concern": "infection, insects, parasites, and stagnation",
-            "Divine Ability": "Constitution or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 5",
             "Minor Boon": "Your commitment to filth draws a small cloud of disease-laden insects. Once, you can summon a cloud of midges, mosquitos, and flies to surround you for 1 minute. Creatures adjacent to you at any point during that time become drained 1, sickened 1, and exposed to a blood-borne illness. Ghlaunder typically grants this boon when you can infect a significant number of creatures.",
             "Moderate Boon": "Ghlaunder teaches you to bide your time, corrupting and infecting until the time is right. When you expose a creature to a disease and it succeeds at its Fortitude save, it is still infected unless it critically succeeds. However, such a creature experiences no effects and the disease does not progress for the first 24 hours, even if the disease is normally fast-acting or someone uses another ability to progress the disease. It's very difficult to detect the infection in the first day; the DC for Medicine checks to do so is 5 higher.",
@@ -1540,7 +1694,13 @@
                 "3rd:": "insect form"
             },
             "text": "Ghlaunder is the god of pestilence, infection, and insects. His form resembles that of a giant mosquito, warped and distended by the parasites he hosts. He leaves malaise in his wake, laying waste to everything he can. Ghlaunder revels in suffering, especially that caused by sickness: the last gasp of air into fluid-filled lungs, the terrorizing dreams that come only from the hottest of fevers. It is said that the Gossamer King was once swaddled in a cocoon, but was released by the curious Desna into the world with a cleave of her starknife. Since then, the goddess has pursued him in a macabre dance, hoping to kill him as they flit between planes.",
-            "divinterDesc": "The Gossamer King's gifts seem bizarre and cruel to those outside of his following, but his faithful crave his gifts zealously and fear his punishments."
+            "divinterDesc": "The Gossamer King's gifts seem bizarre and cruel to those outside of his following, but his faithful crave his gifts zealously and fear his punishments.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Grandmother Spider",
@@ -1567,7 +1727,6 @@
             "Edicts": "be skilled and clever, think for yourself, take due payment for your work, humiliate the powerful",
             "Anathema": "abuse someone you have power over, harm someone who has given you sincere kindness, let a slight go unanswered, own a slave",
             "Areas of Concern": "family, illusion, stories, twilight, weaving",
-            "Divine Ability": "Intelligence or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 5",
             "Minor Boon": "Grandmother Spider rescues your prank from the jaws of failure. Once, when you would fail a Deception check, you critically succeed instead. Grandmother Spider typically grants this boon for deceptions that are necessary for an interesting or consequential prank.",
             "Moderate Boon": "You can feel tugs on the strands of fate. You gain a +2 status bonus to initiative rolls.",
@@ -1591,7 +1750,13 @@
                 "4th:": "glibness"
             },
             "text": "Also known as Nana Anadi, Grandmother Spider began her existence as a servant of the other gods, meant to weave fate and reality into existence. Infuriated at her position as a lackey, she made fools of the greater gods through mischief and disruption. She stole and copied Asmodeus' keys, resulting in widespread chaos, and pilfered some of Sarenrae's fire, leading numerous followers astray. Nimbly avoiding any retribution for her antics, Grandmother Spider rewove the strands of fate for herself, gaining her freedom. She regularly pleads with her brother Achaekek to follow her lead and rebel against the gods, and while he always refuses, seemingly indifferent, Achaekek has on one notable occasion proven vengeful toward those who harm his sister or her followers.",
-            "divinterDesc": "Though the Weaver often condones bad decisions so long as a lesson is learned, and is even willing to accept being fairly tricked herself, cruelty and predation upon the weak draw her outrage."
+            "divinterDesc": "Though the Weaver often condones bad decisions so long as a lesson is learned, and is even willing to accept being fairly tricked herself, cruelty and predation upon the weak draw her outrage.",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Groetus",
@@ -1615,7 +1780,6 @@
             "Edicts": "preach of the upcoming end times, destroy that which has outlived its usefulness, put the suffering out of their misery",
             "Anathema": "artificially extend something's existence or lifespan, spread hope",
             "Areas of Concern": "apocalypse, empty places, oblivion, ruins",
-            "Divine Ability": "Strength or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 6",
             "Minor Boon": "You wield power over disorder. Once, when you are confused, you act normally enough to control your own actions in combat without penalty for the duration, though you still babble incoherently and otherwise behave strangely.",
             "Moderate Boon": "Groetus grants you knowledge to further the end times. Each week, he sends you a cryptic, incoherent message about something important to the end times that will happen in the coming week.",
@@ -1638,7 +1802,13 @@
                 "9th:": "disjunction"
             },
             "text": "Ancient beyond mortal reckoning, Groetus is an entity who cannot be easily understood. He hangs in the sky above the Boneyard, a skull-faced moon constantly observing the passage of the souls below. Events can cause him to draw ominously closer to Pharasma's Spire, or to retreat back to a safer distance, with little obvious rhyme or reason for these actions. He evinces little regard for anything but his singular aim: the dissolution of the universe.",
-            "divinterDesc": "The God of the End Times almost never directly intervenes in the world, but he sometimes offers flashes of insight or inflicts terrible psychic distress."
+            "divinterDesc": "The God of the End Times almost never directly intervenes in the world, but he sometimes offers flashes of insight or inflicts terrible psychic distress.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Gyronna",
@@ -1661,7 +1831,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Expose hypocrisy (real or imagined) in others, make other creatures miserable, demand bribes to spare creatures from your torments",
             "Anathema": "Allow others to slight you without retaliation, seek the approval of society, forgive those who have wronged you",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "ambition",
                 "nightmares",
@@ -1675,7 +1844,13 @@
                 "6th:": "feeblemind"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Hanspur",
@@ -1700,7 +1875,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Learn how to live off the river, guard river travelers from unnatural hazards, save others from drowning",
             "Anathema": "Impose needless laws or restrictions on others, aid daemons or the Horsemen",
-            "Divine Ability": "Strength or Dexterity",
             "domains": [
                 "death",
                 "travel",
@@ -1714,7 +1888,13 @@
                 "4th:": "solid fog"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Jaidi",
@@ -1738,7 +1918,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Encourage hard work that benefits all, ensure the health of crops and vegetation",
             "Anathema": "Destroy healthy crops, waste food, refuse to help others in your community",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "family",
                 "might",
@@ -1752,7 +1931,13 @@
                 "3rd:": "wall of thorns"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Kazutal",
@@ -1777,7 +1962,6 @@
             "Edicts": "defend your people, provide for those who need you, oppose those who unjustly lord power over others, demonstrate devotion to things you love",
             "Anathema": "own a slave, force a creature to act against its will, refuse to give aid to an ally, enforce an unjust law",
             "Areas of Concern": "safety, liberty, and community",
-            "Divine Ability": "Strength or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 7",
             "Minor Boon": "With Kazutal's blessing, food tastes richer. Any meal that you eat tastes delicious and has improved nutritional value. This doesn't protect you from anything dangerous in your food, but it also doesn't prevent you from tasting those dangerous elements of the food.",
             "Moderate Boon": "You always seem to find safe shelter when you most need it. Once per day, you can cast *rope trick* as a divine innate spell.",
@@ -1800,7 +1984,13 @@
                 "4th:": "stoneskin"
             },
             "text": "Kazutal, also known as Mother Jaguar or Lady Jaguar, is an old deity, revered for thousands of years on the continent of Arcadia. Ages ago, she was worshipped in the Razatlani Empire as a goddess of might and protection in war. After the catastrophe of Earthfall, however, her edge softened; those who struggled to put the world back together called upon her to protect their neighbors and came together under her guidance to build strong bonds of community and support.",
-            "divinterDesc": "Mother Jaguar rewards those who uphold a sense of community and bestows punishments upon those who use her name and convictions to admonish or exclude perceived outsiders."
+            "divinterDesc": "Mother Jaguar rewards those who uphold a sense of community and bestows punishments upon those who use her name and convictions to admonish or exclude perceived outsiders.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Kurgess",
@@ -1826,7 +2016,6 @@
             "Edicts": "compete to your full potential, claim victory or accept defeat with grace, seek always to better yourself, encourage others to strive toward their own potential for greatness",
             "Anathema": "cheat at honorable contests, dishonor those who have lost or failed (including defeated or slain enemies), engage in reckless or needless destruction or bloodshed",
             "Areas of Concern": "healthy competition, sport, and physical development",
-            "Divine Ability": "Strength or Constitution",
             "divinterSource": "Gods & Magic - Web Supplement pg. 7",
             "Minor Boon": "The Strong Man blesses you with a measure of his strength. Increase your maximum and encumbered Bulk limits by 2.",
             "Moderate Boon": "You fear no exertion. You can employ exploration tactics normally while fatigued.",
@@ -1847,7 +2036,13 @@
                 "3rd:": "haste"
             },
             "text": "Once a mortal farm boy from Taldor who had superhuman strength from youth, Kurgess's selfless sacrifice on the field of competition heralded his rise to godhood. Known as the Strong Man, Kurgess stands as both champion and shining example to those who seek athletic achievement and to give their all in competition, regardless of whether they are victorious or not.",
-            "divinterDesc": "The Strong Man's gifts reflect his mastery of might."
+            "divinterDesc": "The Strong Man's gifts reflect his mastery of might.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Lissala",
@@ -1870,7 +2065,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Work hard and demand others do so as well, cooperate or avoid conflict with ophidian creatures",
             "Anathema": "Disobey a superior, shirk your duties, destroy a book",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "fate",
                 "glyph",
@@ -1884,7 +2078,13 @@
                 "6th:": "dominate"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Milani",
@@ -1909,7 +2109,6 @@
             "Edicts": "confront oppression in all its forms, defend the common folk, overcome despair to seize victory",
             "Anathema": "abandon those in need, enslave or oppress others, harm the innocent through direct or inadvertent action",
             "Areas of Concern": "devotion, hope, and uprisings",
-            "Divine Ability": "Strength or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 7",
             "Minor Boon": "Once, when you roll a failure on a Deception or Stealth check to protect an uprising from discovery, you critically succeed instead. Milani typically grants this boon for extremely significant checks on which the uprising's survival hinges.",
             "Moderate Boon": "When you use it to protect others, your shield blooms with roses brimming with razor-sharp thorns. You gain the Shield Warden feat, even if you don't meet its prerequisites. If you already had that feat, if your shield takes damage from a melee Strike in defense of your ally, the attacker takes piercing damage equal to half the shield's Hardness.",
@@ -1930,7 +2129,13 @@
                 "4th:": "fire shield"
             },
             "text": "Milani is the patron mother of those who war against oppression, rewarding those willing to sacrifice their lives and use whatever tools are available to fight for those who cannot defend themselves, especially people who have been captured or enslaved. Throughout Golarion, Milani is also known as the Everbloom, as the symbol of her church is a beautiful rose growing from blood-soaked soil.",
-            "divinterDesc": "The Everbloom rewards those who put the needs of others first, especially when combating oppressive forces, and she doesn't hesitate to impede any who enslave others or persecute the defenseless."
+            "divinterDesc": "The Everbloom rewards those who put the needs of others first, especially when combating oppressive forces, and she doesn't hesitate to impede any who enslave others or persecute the defenseless.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Naderi",
@@ -1954,7 +2159,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Comfort and encourage lovers, help the suffering escape their circumstances in life or in death",
             "Anathema": "Dismiss or mock a creature's grief, separate lovers, torture a creature",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "death",
                 "passion",
@@ -1968,7 +2172,13 @@
                 "5th:": "drop dead"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Nivi Rhombodazzle",
@@ -1995,7 +2205,6 @@
             "Edicts": "take risks and savor the consequences whether good or ill, use stealth and guile over violence when dealing with the fallout from your risk-taking, learn the rules and strategies of games of chance played wherever you travel",
             "Anathema": "break the established rules or terms of a wager, use violence to avoid the consequences of a wager",
             "Areas of Concern": "gambling, gems, gnomes, stealth",
-            "Divine Ability": "Dexterity or Intelligence",
             "divinterSource": "Gods & Magic - Web Supplement pg. 8",
             "Minor Boon": "Those who have earned Nivi's trust are blessed with wild turns of luck in the worst of circumstances. Once, instead of attempting the check you would normally roll, you attempt a DC 11 flat check with the same results. Nivi always grants this boon when the odds are stacked against you (though this same effect is an alternate to her minor curse if she uses it for a check when you would have been very likely to succeed).",
             "Moderate Boon": "Nivi bestows a fraction of her skill at pushing consequences down the road. Once per day, after attempting a check, you can roll a second time. You must use the result of the second roll, even if it is worse. This is a fortune effect. At any point after you use this boon, the GM can replace one of your check results with the first result of the check you attempted when using this boon; this delayed result can't be further delayed, prevented, or affected in any way, even by other divine intercessions.",
@@ -2019,7 +2228,13 @@
                 "4th:": "private sanctum"
             },
             "text": "Goddess of gems, stealth, and gambling, Nivi Rhombodazzle is the ultimate high roller, said to have won her divinity from the dwarven god Torag in exchange for a gemstone. She was once a mortal gnome who loved the thrill of an exciting wager, up to and including the moment when the dice turned against her. Eventually, Nivi's debts grew too great for her to remain in her surface home, and she fled into the depths of the Darklands to evade the wrath of her creditors. Most of her adventures in the lightless lands are lost to time and history, but she ultimately emerged reborn as a goddess, hailed as the first of the svirfneblin-uncanny underground gnomes with unique magical abilities and immunity to the dread Bleaching, a wasting curse that claims the lives of gnomes who succumb to boredom and ennui.",
-            "divinterDesc": "The Grey Polychrome is a carefree and self-indulgent deity who detests using violence where wits will serve. She rewards cunning in her followers and punishes crudeness."
+            "divinterDesc": "The Grey Polychrome is a carefree and self-indulgent deity who detests using violence where wits will serve. She rewards cunning in her followers and punishes crudeness.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Nocticula",
@@ -2044,7 +2259,6 @@
             "Edicts": "create art true to yourself, protect marginalized artists, punish those who take advantage of offered trust and shelter",
             "Anathema": "deny shelter to the desperate, destroy harmless art you dislike, finish a work of art during daylight hours",
             "Areas of Concern": "artists, exiles, midnight",
-            "Divine Ability": "Dexterity or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 8",
             "Minor Boon": "The night sky inspires you in a specific way. Once, when you roll a failure on a Crafting or Performance check under the night sky, you critically succeed instead. Nocticula typically grants this boon for a consequential piece of artwork or performance.",
             "Moderate Boon": "You draw on the power of midnight to guide you on your journeys. You gain darkvision. If you already had darkvision, you can cast *darkness* once per day as a divine innate spell.",
@@ -2065,7 +2279,13 @@
                 "4th:": "creation"
             },
             "text": "For most of her existence, Nocticula was a patron of assassins and succubi, a demon lord feared by other demon lords for her skill at assassinating the competition. Those days are behind Nocticula, for she has risen to the role of the Redeemer Queen, a patron of marginalized artists and protector of those cast out from society. She is now feared among her former peers for her persuasive words that tempt them away from their place in the Abyss and toward redemption. Her faith is strongest in the eastern reaches of New Thassilon, where her most powerful exile, Queen Sorshen, seeks to build a nation that welcomes those whom others have cast out.",
-            "divinterDesc": "The Redeemer Queen smiles upon those who seek to better themselves through introspection, but she is quick to reward betrayal with a stinging rebuke."
+            "divinterDesc": "The Redeemer Queen smiles upon those who seek to better themselves through introspection, but she is quick to reward betrayal with a stinging rebuke.",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ravithra",
@@ -2107,7 +2327,8 @@
                 "(snake only), 4th:": "clairvoyance"
             },
             "text": "The Mother of Nagas, the Karmic Pillar, and the Chalice-Bearer of the danavas, Ravithra was decapitated and brought low by treachery. She grants boons only to mortal champions who seek to topple the treacherous and to restore her to her rightful role.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": []
         },
         {
             "name": "Sivanah",
@@ -2135,7 +2356,6 @@
             "Edicts": "show the beauty in illusions, pursue the nature of truth, respect the need for secrets",
             "Anathema": "use illusions and shadows to harm another creature, reveal a secret you have sworn to keep",
             "Areas of Concern": "illusions, mysteries, reflections, secrets",
-            "Divine Ability": "Wisdom or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 9",
             "Minor Boon": "Sivanah prevents your enemies from pulling off your veil. Once, when a foe rolls a success on a Perception check to disbelieve your illusion, it gets a critical failure instead. Sivanah typically grants this benefit to protect an elaborate or consequential illusory deception, and she never uses it to improve the effect of a harmful illusion.",
             "Moderate Boon": "You wear a veil of illusion wherever you go. You can cast *illusory disguise* at will as an innate divine spell.",
@@ -2158,7 +2378,13 @@
                 "5th:": "shadow siphon"
             },
             "text": "No ancient record reveals the truth of Sivanah's origins; in fact, only recent documents record her existence at all. The Seventh Veil is widely regarded as the goddess of illusion magic, often portrayed as a figure disguised by seven veils. Legends state that each face underneath the first six of her seven veils is of a different ancestry-human, elf, halfling, gnome, anadi, and naga- but the seventh face is never shown, believed to mask the goddess's true form. Some theologians believe Sivanah hails from the Shadow Plane, though the goddess's true nature and form continue to be topics of debate. Even her female visage, while agreed upon by her followers, could likewise be an illusion. Her goals are hidden from even her most faithful, which some believe to have hampered the faith's growth and influence beyond the level of a cult.",
-            "divinterDesc": "The Seventh Veil abhors the use of illusion to cause harm and detests anyone who discourages or corrupts the process of truth-seeking. The goddess works actively against the faith of Zon-Kuthon and his clerics' use of shadow."
+            "divinterDesc": "The Seventh Veil abhors the use of illusion to cause harm and detests anyone who discourages or corrupts the process of truth-seeking. The goddess works actively against the faith of Zon-Kuthon and his clerics' use of shadow.",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Thamir",
@@ -2181,7 +2407,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Seize any opportunity that would benefit you, solve your problems With Violence, hide your true intentions",
             "Anathema": "Steal from the poor, beg for help or mercy from a fellow worshipper of Thamir",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "ambition",
                 "confidence",
@@ -2195,7 +2420,13 @@
                 "6th:": "mislead"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Walkena",
@@ -2218,7 +2449,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Uphold Mzali's laws, tend to Walkena and obey his instructions, oppose exploitation of the Mwangi Expanse",
             "Anathema": "Consort or trade with non-Mwangi peoples, defy Walkena's orders",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "family",
                 "freedom",
@@ -2232,7 +2462,13 @@
                 "4th:": "wall of fire"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ydersius",
@@ -2269,7 +2505,8 @@
                 "6th:": "purple worm sting"
             },
             "text": "The serpentfolk god is not dead, but in his decapitated state, he might as well be. Reduced to a feral, animalistic existence, Ydersius is even less aware of his legacy than the lowest of the aapoph. Ydersius's symbol is a snake's skull surrounded by a skeletal ouroboros.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": []
         },
         {
             "name": "Zyphus",
@@ -2292,7 +2529,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Set pointless traps, spread nihilism, encourage deadly accidents",
             "Anathema": "Spread hope, provide aid to Pharasmins",
-            "Divine Ability": "Dexterity or Constitution",
             "domains": [
                 "death",
                 "sorrow",
@@ -2306,7 +2542,13 @@
                 "6th:": "phantasmal calamity"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Anubis",
@@ -2331,7 +2573,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Lay bodies to rest, destroy undead, be impartial in judgment",
             "Anathema": "Desecrate a corpse, rob a tomb, trap a soul",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "death",
                 "protection",
@@ -2345,7 +2586,13 @@
                 "5th:": "wall of stone"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Bastet",
@@ -2370,7 +2617,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Learn secrets, tempt others into revelry, kill harmful snakes and evil spirits, heal diseases",
             "Anathema": "Kill or abuse a house cat, abandon a child, choose to marry",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "nature",
                 "passion",
@@ -2384,7 +2630,13 @@
                 "4th:": "private sanctum"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Bes",
@@ -2408,7 +2660,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Aid childbirths, spread joy and celebration, protect sleeping creatures",
             "Anathema": "Harm or neglect a child, separate families, use magic to corrupt dreams",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "earth",
                 "family",
@@ -2422,7 +2673,13 @@
                 "3rd:": "enthrall"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Hathor",
@@ -2445,7 +2702,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Give wealth to new families, aid traders and miners, support musicians, protect and encourage lovers",
             "Anathema": "Discriminate or slight someone based on appearance, intentionally disfigure a creature, refuse food to the starving",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "family",
                 "passion",
@@ -2459,7 +2715,13 @@
                 "8th:": "uncontrollable dance"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Horus",
@@ -2484,7 +2746,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Protect those you have authority over, maintain harmony in your community",
             "Anathema": "Undermine a rightful ruler, serve a usurper",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "air",
                 "moon",
@@ -2498,7 +2759,13 @@
                 "4th:": "aerial form (bird only)"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Isis",
@@ -2522,7 +2789,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Provide aid to the sick and wounded, use magic to help others, mourn the cherished dead, ritually purify yourself before entering sacred areas",
             "Anathema": "Reveal sacred rites to the uninitiated, betray your children or your lover, discriminate based on social status",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "family",
                 "healing",
@@ -2542,7 +2808,13 @@
                 "9th:": "shapechange"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ma'at",
@@ -2566,7 +2838,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Defend civilization from chaos, live an honest and just life, be impartial in judgment and reveal the truth",
             "Anathema": "Deal unfairly with your family or community, destroy the environment, lie",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "knowledge",
                 "protection",
@@ -2580,7 +2851,13 @@
                 "5th:": "mind probe"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Osiris",
@@ -2603,7 +2880,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Ensure the health of crops and vegetation, protect the bodies and souls of the worthy dead, avenge the wrongly murdered",
             "Anathema": "Dismember a creature, desecrate a corpse, show ingratitude for a sincere gift",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "change",
                 "healing",
@@ -2617,7 +2893,13 @@
                 "6th:": "tangling creepers"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ra",
@@ -2641,7 +2923,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Bring order to places of chaos, kill evil monsters and fiends, encourage just laws, provide warmth where needed",
             "Anathema": "Avoid personal change, kill a plant or a creature with cold damage, seal a building to completely block sunlight",
-            "Divine Ability": "Strength or Intelligence",
             "domains": [
                 "fire",
                 "nature",
@@ -2655,7 +2936,13 @@
                 "3rd:": "threefold aspect"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Sekhmet",
@@ -2682,7 +2969,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Slaughter your enemies, drink the blood of defeated foes, heal battle injuries",
             "Anathema": "Spare an evil fiend, fail to placate Sekhmet with daily rituals",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "destruction",
                 "healing",
@@ -2696,7 +2982,13 @@
                 "5th:": "moon frenzy"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Selket",
@@ -2720,7 +3012,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Avenge the wronged, protect the dead and the vulnerable, use poison and suffocation, heal others",
             "Anathema": "Poison someone you didn't intend to, harm a creature as punishment for a different creature's crime, desecrate a corpse",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "healing",
                 "magic",
@@ -2734,7 +3025,13 @@
                 "6th:": "purple worm sting"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Sobek",
@@ -2760,7 +3057,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Take what you want, indulge in base desires, feast on luxurious food, kill demons and evil creatures",
             "Anathema": "Cower from fights, despoil the land, kill the innocent",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "might",
                 "protection",
@@ -2774,7 +3070,13 @@
                 "4th:": "dinosaur form (appears as crocodile)"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Thoth",
@@ -2799,7 +3101,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Maintain order in society and the multiverse, innovate scientific and magical knowledge, record events",
             "Anathema": "Upset stable mechanisms or ecosystems, fail to correct false information",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "glyph",
                 "knowledge",
@@ -2813,7 +3114,13 @@
                 "3rd:": "secret page"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Wadjet",
@@ -2836,7 +3143,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Defend your homelands and your people, aid childbirths, grow papyrus, protect sources of clean water",
             "Anathema": "Refuse to help a drowning creature, harm a rightful ruler",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "protection",
                 "travel",
@@ -2850,7 +3156,13 @@
                 "(snake only), 4th:": "fly"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Baalzebul",
@@ -2872,7 +3184,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Convey yourself with regal dignity, claim what you desire and deserve, seek vengeance from those who wrong you",
             "Anathema": "Provoke Baalzebul's envy, show humility",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "air",
                 "ambition",
@@ -2886,7 +3197,13 @@
                 "6th:": "mislead"
             },
             "text": "Baalzebul was one of the first angels of Heaven, a glorious lieutenant who followed Asmodeus in his exodus to Hell. In this new realm, he led the infernal armies and trained several other archdevils as generals. When Asmodeus divided the nine realms of Hell between himself and the eight archdevils, Baalzebul protested, thinking he had earned a place at his god's side. Asmodeus responded by stripping away the archdevil's radiant form, reducing him to a figure composed of swarming flies. Now known as the Lord of Flies, he rules over Cocytus, the frozen seventh layer of Hell, and attracts followers possessed of deep ambition and a powerful drive to triumph.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Barbatos",
@@ -2908,7 +3225,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Veil your motives, make dangerous deals, offer incomplete and ruinous knowledge",
             "Anathema": "Hide any plot against your masters, close or interfere with portals to Hell",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "magic",
                 "nature",
@@ -2922,7 +3238,13 @@
                 "4th:": "clairvoyance"
             },
             "text": "Barbatos is the youngest of the archdevils, and in fact is not truly a devil at all. His true nature remains unknown and perpetually cloaked, but when he appeared at Hell's gates bearing the souls of an entire mortal world and transformed them into Hell's first legion of barbazus as an offering, the Prince of Darkness saw fit to grant Barbatos rulership over Hell's first layer, Avernus. As Hell's doorwarden, Barbatos oversees the spaces between worlds, and his followers are those who tread such interstitial paths and hold no qualms about the ethics of their journeys.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Belial",
@@ -2944,7 +3266,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Indulge your basest desires, create deadly weapons",
             "Anathema": "Impede an act of high hedonism, become too attached to a lover or project",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "change",
                 "passion",
@@ -2958,7 +3279,13 @@
                 "3rd:": "enthrall"
             },
             "text": "The lord of Hell's fourth layer, Phlegethon, is Belial. The Pale Kiss was created by Asmodeus as an object of adoration, with perfect form and beauty in the eyes of every creature. As a result, Belial has a virtually unlimited malleability of form, shifting between shapes almost constantly. His appearance is often as dualistic as his personality: half his body beautiful and half grotesque, much as he revels equally in pleasure and pain. As he is a creature of carnal desires, so are his followers: those who crave forbidden pleasures of the flesh but hide behind masks of respectability.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Dispater",
@@ -2981,7 +3308,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Uphold absolute law, pursue perfection in your surroundings, speak with refinement",
             "Anathema": "Act above your station, neglect your defenses, betray a lover",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "cities",
                 "confidence",
@@ -2995,7 +3321,13 @@
                 "6th:": "flesh to stone"
             },
             "text": "Hell's second layer is the Infernal City, Dis, and its ruler is the archdevil Dispater. The Iron Lord is the architect of the orderly perfection of Hell as a blueprint for the rest of the multiverse, responsible for Dis's own dark and startling perfection. He remains distant from the scheming and machinations of the other archdevils and the Material Plane, instead modeling calm and deliberate action combined with ruthless, merciless arrogance. As the most urbane of the archdevils, he attracts many followers among those who wish to see Hell's dark majesty spread across the universe.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Geryon",
@@ -3017,7 +3349,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Hoard knowledge, test the boundaries of taboo, spread falsehoods to dupe the foolhardy",
             "Anathema": "Declare knowledge heresy or forbidden, break your word",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "might",
                 "truth",
@@ -3031,7 +3362,13 @@
                 "(snake only), 3rd:": "hypercognition"
             },
             "text": "Once the mightiest of asura ranas, Geryon betrayed hundreds of Hell's original asura inhabitants to aid Asmodeus in claiming the plane, in the process earning himself the title the Source of Lies. His realm of Stygia, Hell's fifth layer, hews most closely to the nature of Hell before Asmodeus reshaped the plane, and it contains the sunken ruins of countless cities and libraries predating the war against Heaven. The archdevil hoards knowledge and secrets-especially that which has been forbidden- while spreading falsehoods and heresies to mislead the ignorant, and his followers revel in the same.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Mammon",
@@ -3053,7 +3390,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Gain financial control over others, gather new wealth, count your riches",
             "Anathema": "Leave the cult of Mammon, allow those who steal from you to go unpunished",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "ambition",
                 "creation",
@@ -3067,7 +3403,13 @@
                 "7th:": "magnificent mansion"
             },
             "text": "Mammon, the Grasping One, oversees the vast treasuries of Hell secured in the vaults of Erebus, Hell's third layer. As his angelic form was slain, he has no form of his own, so instead he infuses the very wealth that he guards, taking forms composed of riches and extending his senses out through each nigh-uncountable coin-he knows well the exact sum held in Hell's vaults and the greatest treasures among them. His worshippers are the greedy rich and poor alike, and he often arranges for such mortals to stumble across a 'lucky copper' through which he whispers encouragements for the bearer to indulge in greater and greater vices, eventually claiming their soul as his own.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Mephistopheles",
@@ -3089,7 +3431,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Master laws and use them to your benefit, enable the desperate, excoriate others with veiled mockery",
             "Anathema": "Break a contract you made, get caught breaking the law",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "glyph",
                 "knowledge",
@@ -3103,7 +3444,13 @@
                 "5th:": "subconscious suggestion"
             },
             "text": "The archdevil Mephistopheles was shaped of the ashes and fire of Hell itself to convey the plane's will. The lord of Caina, Hell's eighth layer, he is a conniving schemer and a brilliant politician, quick to offer insults both blatant and cloaked behind silvered words. A master of rule, law, and words, he is the creator of the renowned agreements known as infernal contracts, crafted to damn mortal souls through their own ambitions. He views mortals as nothing more than a source of power for the infernal realm, but he nevertheless has followers who share his affinity for the power of law and loophole.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Moloch",
@@ -3125,7 +3472,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Spread Hell's order through war, convert communities to sole worship of Moloch, sacrifice creatures in fire",
             "Anathema": "Defy a military superior, flee in battle [unless ordered to do so], lose your combat edge due to your vices",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "duty",
@@ -3139,7 +3485,13 @@
                 "7th:": "fiery body"
             },
             "text": "The general of Hell's armies, Moloch, embodies infernal discipline and incomparable destructive power. Across his ream of Malebolge, the sixth layer of Hell, the Ashen Bull trains countless legions of devils to wage unending war. He not only teaches obedience, but demands it, punishing even the slightest misstep or insurrection with immediate, fiery retribution. Despite his harsh nature, Moloch is the most widely worshipped of the archdevils among mortals, as he is the most likely to answer supplicants' mundane pleas. In exchange, he asks only their souls to add to his endless armies-a price many are willing to pay.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Abraxas",
@@ -3163,7 +3515,6 @@
             "Edicts": "Learn and hoard forbidden magic, steal secrets from others",
             "Anathema": "Destroy forbidden lore, reveal the entirety of a secret",
             "Areas of Concern": "forbidden lore, magic, and snakes",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "destruction",
                 "knowledge",
@@ -3183,7 +3534,13 @@
                 "9th:": "disjunction"
             },
             "text": "Abraxas, the Master of the Final Incantation, is the demon lord of forbidden lore, magic, and snakes. Abraxas has an encyclopedic knowledge of magical formulas and destructive secrets, favoring those that inflict suffering and destruction. His Final Incantation is a word of power that can unravel the mightiest of spells and unmake even artifacts. He takes the form of a viper-legged humanoid with a fanged, deformed bird's head. Abraxas's cults are most prevalent among the drow of Golarion, but small circles devoted to him can be found in most major cities on the surface as well.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Angazhan",
@@ -3205,7 +3562,6 @@
             "source": "Gods & Magic pg. 124",
             "Edicts": "Commit acts of brutal violence, test yourself against nature, make animals more dangerous",
             "Anathema": "Cower from fights, allow yourself to be resurrected instead of reincarnated",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "might",
@@ -3219,7 +3575,13 @@
                 "(ape only), 5th:": "moon frenzy"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Baphomet",
@@ -3244,7 +3606,6 @@
             "Edicts": "Confuse paths and roads, outwit your foes instead of overpowering them, pace labyrinths",
             "Anathema": "Kill something that cannot significantly harm you, bargain with Asmodeus",
             "Areas of Concern": "beasts, labyrinths, and minotaurs",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "indulgence",
                 "might",
@@ -3258,7 +3619,13 @@
                 "8th:": "maze"
             },
             "text": "Baphomet, Lord of the Labyrinth, is the demon lord of beasts, labyrinths, and minotaurs. Baphomet was originally a consort of Lamashtu who achieved demon lord status after escaping from imprisonment in a labyrinth constructed by Asmodeus. Baphomet appears as an enormous emaciated minotaur with feathered wings and a goat-like head that bears three horns, as well as a blazing pentagram branded into his forehead. Baphomet's cults are among the most prolific in Golarion-human-dominated secret societies devoted to the demon lord are present in many cities and may have members ensconced in positions of political power, while most minotaurs prefer his patronage to that of Lamashtu.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Cyth-V'sug",
@@ -3281,7 +3648,6 @@
             "Edicts": "Corrupt all that exists with parasites or fungus, promote the growth of fungus, feast on rotten flesh or fungus",
             "Anathema": "Purify your food, cure a disease or kill a parasite, tolerate another demon lord or their servants (except Treerazer)",
             "Areas of Concern": "disease, fungus, and parasites",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "change",
                 "decay",
@@ -3295,7 +3661,13 @@
                 "5th:": "plant form"
             },
             "text": "Cyth-V'sug, Prince of the Blasted Heath, is the demon lord of disease, fungus, and parasites. Originally a qlippoth lord, he was exiled by his peers for accepting mortal worshippers. Transformed into one of the demons he despises, Cyth-V'sug seeks to devour all life to put an end to demons and, ultimately, himself. He most often appears as an enormous draconic figure of snarled vines, fungal growths, and flailing tentacles. Cyth-V'sug is most often worshipped by recluses who seek to bring decay and destruction to their environs, though denizens of the Darklands also pay homage to him.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Dagon",
@@ -3319,7 +3691,6 @@
             "Edicts": "Swim underwater, improve your own strength, encourage the spread of dangerous sea monsters",
             "Anathema": "Break a sworn oath, settle in a land-locked area, share Dagon's secrets with outsiders",
             "Areas of Concern": "deformity, the sea, and sea monsters",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "change",
                 "destruction",
@@ -3333,7 +3704,13 @@
                 "6th:": "chain lightning"
             },
             "text": "Dagon, the Shadow in the Sea, is the demon lord of deformity, the sea, and sea monsters. He holds court in an infinite ocean covered in disconcerting islands and deep-sea trenches filled with incomprehensible sunken cities. He appears as a massive creature with the lower body of an eel, a head reminiscent of deep-sea predators, and four thrashing tentacles in place of arms. Dagon began as a qlippoth, and no mortal understands his transformation into a demon lord, though it earned him the enmity of his former kin. Dagon is primarily worshipped by boggards, sahuagin, skum, and marsh giants, though desperate or depraved coastal villages have been known to pledge themselves to the demon lord.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Gogunta",
@@ -3369,7 +3746,8 @@
                 "5th:": "black tentacles"
             },
             "text": "Gogunta, Song of the Swamp, is the demon lord of amphibians, boggards, and swamps. Gogunta is worshipped as a goddess by boggards, who believe her to be an ascended mobogo, though scholars suspect she was a former hezrou who gained the favor of Dagon. Lending credence to this latter theory, her realm, a stinking salt marsh, is located within Dagon's oceanic realm. Gogunta appears as an enormous, multi-headed frog with dozens of eyes and even more tongues, though boggards typically depict her as a titanic boggard queen.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": []
         },
         {
             "name": "Kabriri",
@@ -3394,7 +3772,6 @@
             "Edicts": "Eat the flesh of your own kind",
             "Anathema": "Reveal secrets of the dead to nonbelievers, despoil grave markers",
             "Areas of Concern": "ghouls, graves, and secrets kept by the dead",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "indulgence",
                 "knowledge",
@@ -3408,7 +3785,13 @@
                 "3rd:": "paralyze"
             },
             "text": "Kabriri, Him Who Gnaws, is the demon lord of ghouls, graves, and secrets kept by the dead. According to legend, Kabriri is the reborn form of the first humanoid to devour his kin in life. His realm, Everglut, is connected to graveyards throughout the multiverse by a snarled network of tunnels that bring knowledge and sacrifices to the demon lord. Kabriri appears as a hulking ghoul with elven ears, teeth filed to points, an unnaturally long tongue, ashen skin, and cloven hooves. He is worshipped primarily by ghouls, ghasts, and lacedons.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Kostchtchie",
@@ -3431,7 +3814,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Avenge all slights three times over, kill all witches",
             "Anathema": "Make a deal with Baba Yaga or her children, defer to or obey a woman",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "cold",
                 "destruction",
@@ -3445,7 +3827,13 @@
                 "5th:": "cone of cold"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Nurgal",
@@ -3469,7 +3857,6 @@
             "Edicts": "Wage war in the desert, deny water to your foes",
             "Anathema": "Heal a sunburn, change your name",
             "Areas of Concern": "deserts, senseless warfare, and the sun",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "destruction",
                 "dust",
@@ -3483,7 +3870,13 @@
                 "3rd:": "cup of dust"
             },
             "text": "Nurgal, the Shining Scourge, is the demon lord of deserts, senseless warfare, and the sun. He was formerly a fully fledged deity of ancient Azlant, but fell to demigodhood after being defeated in combat. Nurgal represents the sun's potential for devastation, and his followers venerate him out of cowed awe. The demon lord appears as a muscular, tanned man with the head and lower body of a golden lion and a dragon's tail. He is almost always depicted as wielding a mace in the form of a miniature sun, held in a taloned hand. Nurgal's worshippers are primarily found in the deserts of Garund, Ninshabur, and Qadira.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Pazuzu",
@@ -3506,7 +3899,6 @@
             "Edicts": "Tempt others to immoral acts, revel in flight, possess or magically influence others to cause calamities",
             "Anathema": "Deny a flying creature the ability to fly, abuse Pazuzu's name or call on Pazuzu for help, aid worshippers of Lamashtu",
             "Areas of Concern": "the sky, temptation, and winged creatures",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "air",
                 "swarm",
@@ -3520,7 +3912,13 @@
                 "4th:": "fly"
             },
             "text": "Pazuzu, King of the Wind Demons, is the demon lord of the sky, temptation, and winged creatures. He counts himself among the most ancient of demon lords, though his constant warring with Lamashtu has hindered his accumulation of power to the point of denying him godhood. He is exceptionally active in meddling in mortal affairs and takes great pleasure in possessing and corrupting good-hearted folk who invoke his name. Pazuzu appears as a humanoid figure with eagle's talons, two pairs of bird wings, a scorpion tail, and an avian demonic head. He is worshipped by harpies, other evil winged creatures, and by countless champions and clerics who fell from grace at his temptations.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Shax",
@@ -3544,7 +3942,6 @@
             "Edicts": "Plot and commit murders, tell lies, torture creatures",
             "Anathema": "Sleep in a building with fewer than five rooms, allow a victim to escape due to gloating",
             "Areas of Concern": "envy, lies, and sadistic murders",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "ambition",
                 "death",
@@ -3558,7 +3955,13 @@
                 "3rd:": "haste"
             },
             "text": "Shax, the Blood Marquis, is the demon lord of envy, lies, and sadistic murders. Shax's capacity for cruelty is legendary even among the ranks of demon lords, and he takes extreme pleasure in watching the last light of hope fade from the eyes of his victims. He is the original creator of the babau demons, and those whom he personally flays and corrupts with Abyssal influence remain exemplars of their kind. Shax appears as a human man with a dove's head, feet, and wings, carrying countless knives and other weapons all over his body. Shax is most frequently worshipped by sadists, lone murderers, and serial killers.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Sifkesh",
@@ -3581,7 +3984,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Spread doubt among the faithful, ruin the reputation of religions, provoke wrongdoers to suicide instead of allowing for redemption",
             "Anathema": "Spread hope, offer forgiveness, sincerely honor or call upon another god",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "nightmares",
                 "pain",
@@ -3595,7 +3997,13 @@
                 "5th:": "subconscious suggestion"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Treerazer",
@@ -3633,7 +4041,8 @@
                 "6th:": "tangling creepers"
             },
             "text": "Treerazer, the Lord of the Blasted Tarn, is a nascent demon lord of pollution and the corruption of nature, believed by many to be an exiled servant or spawn of Cyth-V'sug who was banished to Golarion after a failed attempt at supplanting the demon lord. Though Treerazer is a nascent demon lord, and thus lacks the power of a true demon lord, he is perhaps most noteworthy among those who have a stake in Golarion due to his physical presence within the Tanglebriar, a corrupted, fetid swamp that was once the southern edges of the elven nation of Kyonin. He is served by devoted cultists in and around Kyonin, though small pockets of believers can be found around Golarion working furtively to free him in hopes of gaining his favor upon his ascension. Treerazer's religious symbol is a bleeding dead tree that's been split in half.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": []
         },
         {
             "name": "Zevgavizeb",
@@ -3657,7 +4066,6 @@
             "Edicts": "expand your clutch's domain, dominate your enemies, demonstrate mastery over your crafts and environment, devour the weak",
             "Anathema": "surrender in combat, express weakness in the face of adversity, show mercy to the weak",
             "Areas of Concern": "caverns, reptiles, and troglodytes",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "might",
@@ -3671,7 +4079,13 @@
                 "8th:": "earthquake"
             },
             "text": "The Beast of Gluttondark's sphere of influence encompasses caverns, reptiles, the strong, and all-consuming hunger. A primordial qlippoth-turned-demon lord, Zevgavizeb seems to care little for his followers, and so he is more often propitiated than worshipped.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Zura",
@@ -3695,7 +4109,6 @@
             "Edicts": "Drink blood, seek vampirism, cause bleed damage",
             "Anathema": "Expose vampires, heal a bloody wound without drinking blood from it first",
             "Areas of Concern": "blood, cannibalism, and vampires",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "delirium",
                 "indulgence",
@@ -3709,7 +4122,13 @@
                 "6th:": "dominate"
             },
             "text": "Zura, the Vampire Queen, is the demon lord of blood, cannibalism, and vampires. According to legend, she is the reincarnated form of an Azlanti queen who indulged in blood rites and acts of cannibalism in a quest for eternal life. After death, she was reborn as a unique vampiric succubus who quickly ascended to the status of demon lord. Though many of her cults died out with the Azlanti empire, Zura is still worshipped by vampires and those aspiring to become vampires, particularly within Cheliax and Ustalav, as well as among the drow of the Darklands.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Angradd",
@@ -3732,7 +4151,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Seek and destroy evil, study evil to learn the best way to destroy it, train others in righteous ways",
             "Anathema": "Allow weaker evils to survive due to the presence of larger evils, deceive others outside of tactical gain",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "fate",
                 "fire",
@@ -3746,7 +4164,13 @@
                 "3rd:": "fireball"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Bolka",
@@ -3770,7 +4194,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Encourage those seeking love, seek the beauty in others, support others' relationships",
             "Anathema": "Betray your spouse, disrupt a genuine marriage, prevent a suitor from seeking a partner",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "confidence",
                 "family",
@@ -3784,7 +4207,13 @@
                 "6th:": "collective transposition"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Dranngvit",
@@ -3808,7 +4237,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Help reclaim just debts, seek appropriate vengeance against transgressions",
             "Anathema": "Allow a slight to go unrecognized, avoid repaying a debt, force others into debts you know are unpayable",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "knowledge",
                 "might",
@@ -3822,7 +4250,13 @@
                 "5th:": "passwall"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Droskar",
@@ -3846,7 +4280,6 @@
             "source": "Gods & Magic pg. 127",
             "Edicts": "achieve goals at any cost, continually improve your abilities, establish dominance, work ceaselessly",
             "Anathema": "fail to work toward goals or grow in skill, relax excessively or give into sloth",
-            "Divine Ability": "Constitution or Intelligence",
             "domains": [
                 "duty",
                 "earth",
@@ -3864,7 +4297,13 @@
                 "6th:": "dominate"
             },
             "text": "Cast out and cursed by Torag, the Dark Smith works constantly to prove his significance, cheating and enslaving others to further his goal",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Folgrit",
@@ -3888,7 +4327,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Maintain the sanctity of a home, remain patient with others, take in those without families",
             "Anathema": "Abandon your family, fail to defend your neighbors",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "cities",
                 "family",
@@ -3902,7 +4340,13 @@
                 "9th:": "resplendent mansion"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Grundinnar",
@@ -3925,7 +4369,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Attempt to bridge the gap between feuding sides, maintain just treaties, maintain relations with neighbors",
             "Anathema": "Sow discord among friends and allies, attack during parley",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "confidence",
                 "family",
@@ -3939,7 +4382,13 @@
                 "6th:": "wall of force"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Kols",
@@ -3963,7 +4412,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Seek those that break oaths and enforce just restitution, uphold your promises",
             "Anathema": "Lie, dishonor yourself or your family, shirk your duties, break an oath",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "duty",
                 "knowledge",
@@ -3977,7 +4425,13 @@
                 "8th:": "unrelenting observation"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Magrim",
@@ -4001,7 +4455,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Perfect a craft or trade, carve runes, destroy undead, aid others with completing unfinished tasks",
             "Anathema": "Treat gravesites irreverently, mistreat your tools, create undead, damage a soul",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "death",
                 "duty",
@@ -4015,7 +4468,13 @@
                 "9th:": "earthquake"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Trudd",
@@ -4038,7 +4497,6 @@
             "source": "Gods & Magic pg. 126",
             "Edicts": "Offer your strength to aid others, protect those weaker than you",
             "Anathema": "Engage in petty showcases of strength, use your strength to take advantage of others",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "confidence",
                 "duty",
@@ -4052,7 +4510,13 @@
                 "4th:": "stoneskin"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Count Ranalc",
@@ -4079,7 +4543,6 @@
             "Edicts": "Work in shadows, hide your nature and motives, plot betrayals or revenge for betrayals",
             "Anathema": "Ask for forgiveness, create permanent or long-lasting sources of light",
             "Areas of Concern": "exiles, shadows, betrayal, and the betrayed",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "confidence",
                 "darkness",
@@ -4093,7 +4556,13 @@
                 "5th:": "shadow walk"
             },
             "text": "Once the lord of darkness and of the chaos of creation, Count Ranalc was cast out long ago by the other Eldest and titled 'the Traitor,' though the Eldest are not forthcoming about what heinous treachery Ranalc committed, and many among his worshippers claim that he was the one who was betrayed. In his new home in a remote corner of the Shadow Plane, Ranalc embraced his banishment and became the patron of exiles, shadows, betrayal, and the betrayed. Ranalc had long held a fascination with the world of Golarion, and he was alternately both friend and foil to the powerful archwizard Nex. On the day Nex besieged the city of Absalom with shadowy beings-beings certainly drawn from Ranalc's domain-the Eldest vanished from reality. Although he continues to grant spells to his devout worshippers, Ranalc has otherwise wholly disappeared. Theories about his disappearance abound, although they are as obscure and as self-contradictory as the enigmatic Eldest ever was.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Imbrex",
@@ -4119,7 +4588,6 @@
             "Edicts": "Pursue your own goals, bring things to their proper ending, split things in half or otherwise create pairs",
             "Anathema": "Offend Imbrex",
             "Areas of Concern": "twins, statues, and endings",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "dreams",
                 "earth",
@@ -4133,7 +4601,13 @@
                 "4th:": "stoneskin"
             },
             "text": "Known as the Twins, Imbrex is the mysterious Eldest of twins, statues, and endings. Appearing as two immense stone statues hundreds of feet tall holding hands and looking outward, Imbrex neither moves nor speaks. The Eldest sometimes communicates with telepathic utterances that rend minds or deliver psychic enlightenment, but they more often express their will through startlingly realistic dreams that sometimes manifest into strange life. An entire city named Anophaeus sprawls at Imbrex's four feet, populated by jaded urbanites, eager aspirants, and prowling dream-creatures made real. An unusually high proportion of those born in Anophaeu are twins, and twins are also common among Imbrex's worshippers. Although Imbrex appears timeless in form, they are intrigued by dramatic endings, particularly apocalypses, and have foreknowledge of disasters to come.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Magdh",
@@ -4158,7 +4632,6 @@
             "Edicts": "Use divination",
             "Anathema": "Lie, share your divinations without payment (no matter how trivial)",
             "Areas of Concern": "foreknowledge, complexity, and triplets",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "fate",
                 "glyph",
@@ -4172,7 +4645,13 @@
                 "6th:": "scrying"
             },
             "text": "Magdh is the Eldest of foreknowledge, complexity, and triplets, and she is the greatest seer in the First World. Most often appearing as a woman with three faces set equidistantly around her head, Magdh looks across the skeins of fate into myriad alternate realities and possible futures. Among all the Eldest, she has the deepest knowledge of reality's true design and the ripples a single action or inaction can create throughout all of existence. Her communications are veiled in conditional language and oddly juxtaposed statements to an almost maddening degree, and thus she never communicates the prophetic truths she sees-so plain to her six eyes-in a straightforward way. Because of their shared knowledge of branching timelines, Shyka and Magdh can communicate more easily with each other about such topics, though the other Eldest are cautious around Magdh, lest a careless comment or errant gesture cause her to predict apocalyptic dooms.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ng",
@@ -4196,7 +4675,6 @@
             "Edicts": "Travel, hide your identity and your motives",
             "Anathema": "Sleep in the same place twice in a row, wear seasonal decorations out of season",
             "Areas of Concern": "changing seasons, secrets, and wanderers",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "knowledge",
                 "magic",
@@ -4210,7 +4688,13 @@
                 "4th:": "blink"
             },
             "text": "Rumors say that to glance upon the hooded face of Ng is to either see truth or face oblivion itself, but the Eldest of changing seasons, secrets, and wanderers keeps his visage perpetually shrouded. He is a serious and stern figure draped in silvery robes that swish around his legs as he walks lonely and distant paths. No carefree wanderer, Ng is a patron of those who travel long distances with purpose, and he sometimes shields them from banditry, treacherous weather, and getting lost. Ng keeps many secrets, even from his followers, and none know what his evidently aimless travels might portend. Ng rules over the seasons as they turn one into another, but he rules far more numerous seasons than the four familiar to Golarion, such as the Season of Carnivorous Light and the Season of Solemn Deliquescence.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ragadahn",
@@ -4236,7 +4720,6 @@
             "Edicts": "Draw spirals, seek primordial secrets, use poison, always carry water",
             "Anathema": "Suffer a linnorm's death curse, destroy a fossil",
             "Areas of Concern": "oceans, linnorms, and sinuous spirals",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "destruction",
                 "vigil",
@@ -4250,7 +4733,13 @@
                 "6th:": "purple worm sting"
             },
             "text": "As boastful as he is bestial, Ragadahn the Water Lord is the Eldest of oceans, linnorms, and sinuous spirals. He appears as a great serpentine dragon in the First World's seas, but he is widely traveled and takes other forms as needed to pursue both martial conquests and amorous affairs. He is widely believed to be the progenitor of all linnorms, and he claims to be the progenitor of all dragons. True dragons stridently contest this assertion, although they wisely decline to do so when in Ragadahn's majestic presence. Failure to deliver proper respect to the arrogant Ragadahn invites his legendary ire, and no supplicant can ever be too flattering for his tastes. Yet for all his tempestuous nature, he is wise, and he holds much otherwise lost and forgotten knowledge.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Shyka",
@@ -4278,7 +4767,6 @@
             "Edicts": "Learn from the past, leave hourglasses in unusual places, give random gifts, create ephemeral things",
             "Anathema": "Willingly tread where time does not pass",
             "Areas of Concern": "entropy, reincarnation, and time",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "decay",
                 "delirium",
@@ -4292,7 +4780,13 @@
                 "7th:": "time beacon"
             },
             "text": "The Eldest of entropy, reincarnation, and time, Shyka the Many is not a single entity but rather multiple beings who travel forward and backward through time. Each has sequentially held the title of Shyka, picking up the mantle and the knowledge that comes with it upon the passing (or disappearance) of a predecessor. Shyka visits so many overlapping temporal locations that other creatures encounter a random-seeming Shyka each time. This Eldest knows of the multiverse's birth as well as its death, having experienced both. Although Shyka claims to merely watch over the continuum of time, it's an open secret that the Eldest makes slight changes in line with their own goals-or requests that their worshippers do so, with abstruse promptings.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "The Green Mother",
@@ -4317,7 +4811,6 @@
             "Edicts": "Frolic in vegetation, manipulate people, use what you kill, prey on the weak",
             "Anathema": "Hold a secret for too long, discriminate against sex workers or use their trade to harm them",
             "Areas of Concern": "carnivorous plants, intrigue, and seduction",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "decay",
                 "indulgence",
@@ -4331,7 +4824,13 @@
                 "5th:": "plant form"
             },
             "text": "The Eldest of carnivorous plants, intrigue, and seduction, the Green Mother personifies the raw thrill and desire found throughout nature. Lush plants that entice prey only to kill with barbs or toxins lie within her authority, as do lustful acts and whispered secrets occurring in wild terrain. Her seductive form shifts from that of a beautiful fey such as nymphs to incorporating natural lures like sweet-smelling flowers and graceful verdant tresses. Just as the Green Mother's form constantly changes, her mood shifts from suggestive temptress to indifferent poisoner. No matter her form or attitude, the Green Mother is among the canniest of the Eldest, and she maintains several loyal agents who keep her well informed about goings-on in the First World and beyond. This information fuels her intrigues among the Eldest, and they all believe it wisest to keep on the Green Mother's good side lest their secrets be seductively whispered into the ears of their enemies.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "The Lantern King",
@@ -4356,7 +4855,6 @@
             "Edicts": "Play pranks, seek new jokes, leave lit lanterns in unusual places",
             "Anathema": "Be completely honest, ruin or explain a good joke",
             "Areas of Concern": "laughter, mischief, and transformation",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "change",
                 "delirium",
@@ -4370,7 +4868,13 @@
                 "6th:": "baleful polymorph"
             },
             "text": "Although the Lantern King most often appears as a floating ball of light surrounded by runes that form a delicate crown, the Eldest of laughter, mischief, and transformation has taken on a dizzying array of figures. He often adopts alternate shapes to play pranks, and even other Eldest are not immune to his mischievous scheming. Although he insists his pranks are intended only to incite levity and bring down imperious snobs, the chaos he creates in the name of good-natured fun is, to his targets, embarrassing at best and sometimes outright lethal. The Lantern King wanders the First World more than other Eldest, and he can be encountered in crowded markets and lonely byways alike. He is frequently accompanied by the Witchmarket, a traveling caravan of entertainers and merchants that serves as his court.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "The Lost Prince",
@@ -4395,7 +4899,6 @@
             "Edicts": "Aid the depressed, wear somber clothing, maintain neutrality, ruminate on the past",
             "Anathema": "Abandon someone who has no family, take public credit for your good deeds",
             "Areas of Concern": "loneliness, sadness, and forgotten things",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "knowledge",
                 "repose",
@@ -4409,7 +4912,13 @@
                 "5th:": "crushing despair"
             },
             "text": "The Eldest of loneliness, sadness, and forgotten things, the Lost Prince spends most of his time brooding in the throne room of his crumbling tower. Although his precise origin is a hotly debated issue, the Lost Prince is known to hail from a place other than the First World. The melancholy lord doesn't speak of his home, and in fact he doesn't speak much at all, as he's prone to bouts of depression powerful enough to leach color from his surroundings and press his coterie of followers into respectful silence. Appearing as a gaunt, pale human man dressed in black finery, the Lost Prince bears vivid red runes on his brow and on the backs of his hands. He is studiously neutral in the schemes of the other Eldest, which makes his opinions and his favor particularly valuable.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Atreia",
@@ -4435,7 +4944,6 @@
             "Edicts": "Burn away corruption, clear the way for new growth, purify tainted areas",
             "Anathema": "Deny a suffering creature warmth, shade, or water; abandon a creature in darkness",
             "Areas of Concern": "fire, purification, and radiance",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "fire",
                 "healing",
@@ -4449,7 +4957,13 @@
                 "4th:": "fire shield"
             },
             "text": "Responsible for fire, purification, and radiance, Atreia the Lambent King is the benevolent elemental lord of fire. When the multiverse was young, Atreia soared across the Plane of Fire as a triple-headed ibis, with wings that burned and eyes of flame, routing evil from the plane. Now, he is imprisoned within the Garnet Brand, a red gem encased in an eternal shroud of steam. Though he cannot hear or grant power to his followers from his prison, some groups of salamanders on the Plane of Fire still honor the Lambent King for his dominion over protection and life-giving fire, as do a few small circles of mortals who hold the discovery and purification of evil above all other causes. Statues depicting his likeness can be found across his former realms, hidden in ancient sites dedicated to healing and holy light.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ayrzul",
@@ -4475,7 +4989,6 @@
             "Edicts": "Use the strength of stone to protect yourself and your secrets, obscure your true motives, slowly poison others",
             "Anathema": "Remove a creature's petrified condition, make a fire larger or hotter than necessary",
             "Areas of Concern": "buried secrets, earth, and metal",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "earth",
@@ -4489,7 +5002,13 @@
                 "(earth only), 6th:": "flesh to stone"
             },
             "text": "Lord of buried secrets, earth, and metal, the Fossilized King Ayrzul is a mystery even on the Plane of Earth. No one has seen the elemental lord of earth outside of his realm, the Blistering Labyrinth, and few know the truth of Ayrzul's nature or the form he takes when he appears. Some say he is an immense, undead crystalline dragon, an ancient genie wizard, or even a discarded splinter from some long-forgotten deity, shed before their primeval destruction. His power, motives, and origins are likewise the subjects of innumerable rumors. This speculation is all inconsequential to the Fossilized King; even the politics of his plane falls outside his notice. Instead, the lord of Earth spends his time plotting against his bitter rival, Ymeri, the elemental lord of fire. Ayrzul's followers include xiomorns-Sairazul's children whom he has stolen-a handful of mephits and other elementals, and groups of humanoids on the Material Plane with an interest in the unseen hostility of the earth.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Hshurha",
@@ -4515,7 +5034,6 @@
             "Edicts": "Revel in formlessness and freedom, humiliate terrestrial creatures, kill foes via falling or hazards from high winds",
             "Anathema": "Deny a flying creature the ability to fly, walk on the earth if you could easily travel otherwise",
             "Areas of Concern": "air, last breaths, and windstorms",
-            "Divine Ability": "Strength or Dexterity",
             "domains": [
                 "air",
                 "cold",
@@ -4529,7 +5047,13 @@
                 "(air only), 4th:": "gaseous form"
             },
             "text": "Hshurha, Duchess of All Winds, is the elemental lord of air, last breaths, and windstorms. She rules the Plane of Air from her translucent palace, Verglas Precessional, surrounded by her court of air elementals, planar dignitaries, and favored guests. The Duchess is naturally invisible, and her true form-if she even has such a thing-is a mystery. Cruel and tyrannical, Hshurha enjoys toying with outsiders in her realm, and she is known to be especially vicious toward creatures with solid forms. She creates and destroys magnificent ice and dust sculptures according to her tumultuous whims, and her machinations often seem convoluted and nonsensical, even to her inner circle. Most on the plane both respect and fear her. The lord of air is worshipped by air elementals as a mother goddess, by invisible stalkers, and by cultists who enjoy catering to capricious whims and unpredictable storms. Despite her cool peace with djinn, some believe she consorts with efreet or uses her invisible stalkers to weaken the djinn's hold on her plane.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Kelizandri",
@@ -4555,7 +5079,6 @@
             "Edicts": "Instill hydrophobia in others, kill your foes by drowning them, sacrifice treasures to the depths of the ocean",
             "Anathema": "Destroy a body of water, use magic to calm the waves",
             "Areas of Concern": "the deep sea, waves, and drowning",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "destruction",
                 "nightmares",
@@ -4569,7 +5092,13 @@
                 "(water only), 4th:": "hydraulic torrent"
             },
             "text": "Kelizandri, the elemental lord of water, oversees the deep sea, waves, and drowning. The Brackish Emperor claims to be the offspring of an ancient god and a brine dragon, and he usually takes the form of an immense aquatic dragon with metallic scales and crystalline talons. He spends much of his time slumbering in his magnificent Palace of Salt and Bones, entertaining himself with rampages of wanton destruction and conquest whenever he wakes. Kelizandri's worshippers include brine dragons, water elementals, and mortals who revere the inhospitable unknowns of the deep sea. He holds no love for marids, having killed the last Saline Padishah, Niloufar the Great, and destroyed her capital city of Arzanib. The lord's domain on the Plane of Water is the Brackish Empire Kelizandrika, a conglomeration of affiliated brine dragon-controlled realms. The most powerful dragons of Kelizandrika's ruling councils are said to advise the elemental lord personally.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Lysianassa",
@@ -4595,7 +5124,6 @@
             "Edicts": "Respect and aid natural cycles, promote life and growth, change to avoid stagnation, swim",
             "Anathema": "Pollute clean bodies of water, dam a river, disrespect sincere gifts of water or drink",
             "Areas of Concern": "currents, tides, and water",
-            "Divine Ability": "Dexterity or Constitution",
             "domains": [
                 "change",
                 "fate",
@@ -4609,7 +5137,13 @@
                 "5th:": "control water"
             },
             "text": "Lysianassa, Empress of the Torrent, is the elemental lord of currents, tides, and water. Before she was trapped in the Gasping Pearl, the benevolent lord of water patrolled her plane as a powerful sailfish made of coral and streaked with mother of pearl. When she realized her capture was imminent, Lysianassa preserved the last of her strength within the Breath of Lysianassa, a vial that allowed her nautilus servant Riam the Unyielding to control the Plane of Water's tides. Since Riam's death, the currents of the Plane of Water have begun to slow, and may eventually come to a halt. Few recall the Empress of the Torrent's name, but cults dedicated to an enigmatic figure called the Queen of the Depths have begun to arise, heralding an event they refer to as the Awakening, and some planar scholars believe these cultists seek to free Lysianassa from her prison.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Ranginori",
@@ -4635,7 +5169,6 @@
             "Edicts": "Open closed areas to fresh air, travel throughout your surroundings daily, fly or make creations that fly",
             "Anathema": "Wrongfully imprison a creature, restrain a creature longer or more tightly than is necessary, suffocate a creature",
             "Areas of Concern": "air, welcome breezes, and thunderstorms",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "air",
                 "freedom",
@@ -4649,7 +5182,13 @@
                 "6th:": "chain lightning"
             },
             "text": "The benevolent elemental lord of air is Ranginori, the Zephyrous Prince, lord of air, welcome breezes, and thunderstorms. When he appears before mortals, Ranginori takes the form of an immense, lion-headed serpent spun from forbidding clouds, with hundreds of clawed feet and a mane that dances with lightning. Recently freed from his imprisonment within the Untouchable Opal by agents of the Pathfinder Society, the Zephyrous Prince has accumulated a small but loyal following in search of liberation, hope, and change for the multiverse. He is regaining his strength and preparing to find and liberate the other benevolent elemental lords, bringing balance back to the Elemental Planes. As the single free benevolent elemental lord, Ranginori is in a vulnerable situation, in desperate need of allies and followers to aid him against the combined might of the evil elemental lords. He has reestablished his realm on the Plane of Air: the Roaring Spark, a floating spiral of ruins that branch outward from a central crack of thunder. As the elemental lord regains his power and his domain returns to life, the vestiges of his ancient keeps and towers rebuild themselves while new branches form.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Sairazul",
@@ -4675,7 +5214,6 @@
             "Edicts": "Shelter others within stone and earth, care for Sairazul's children, aid childbirths, mine responsibly",
             "Anathema": "Damage subterranean natural wonders, collapse an earthen structure on a creature",
             "Areas of Concern": "caves, earth, and gems",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "earth",
                 "family",
@@ -4689,7 +5227,13 @@
                 "4th:": "stoneskin"
             },
             "text": "Sairazul, the Crystalline Queen, is the elemental lord of caves, earth, and gems. Planar scholars who know of the benevolent lord of earth speak of Sairazul as a mother and creator who gave birth to numerous races of outsiders, including agrawghs and xiomorns. She is currently imprisoned within the Moaning Diamond, a pure gemstone encircled by eternally crying winds, unable to contact the outside world. Several of her consorts still live to this day, searching the planes for her prison in the hopes that her release will usher in an era of renewed creation across the Plane of Earth. Though the Crystalline Queen can't grant power of any kind to her followers, a handful of her children on the Plane of Earth remain faithful to their creator, and she is remembered with great reverence by Material Plane cultists who exalt creation and reproduction.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ymeri",
@@ -4715,7 +5259,6 @@
             "Edicts": "Inspire your lessers with zeal and strategy, be passionate and quick of wit, destroy your foes with fire",
             "Anathema": "Extinguish destructive blazes, allow yourself to stagnate or lose motivation",
             "Areas of Concern": "fire, heat, and smoke",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "destruction",
                 "dust",
@@ -4729,7 +5272,13 @@
                 "(fire only), 4th:": "wall of fire"
             },
             "text": "The elemental lord of fire is Ymeri, Queen of the Inferno, lord of fire, heat, and smoke. The sole ruler of the Plane of Fire, Ymeri governs from her Auroric Palace, taking the form of a six-armed reptilian centaur with burning wings. She has systematically destroyed all record of her birth and true origins, claiming to have always existed, and she wages a never-ending war against the other denizens of the Plane of Fire and against the shaitans of the Plane of Earth. Of all the elemental lords, Ymeri has the largest following. Some mephits and most fire elementals revere her, alongside some efreet and a few other creatures of the Plane of Fire, though few salamanders honor her name, and a covert order of efreeti known as the Secret Fire is dedicated to opposing her rule. On Golarion, the Queen of the Inferno is worshipped primarily by cabals of fire wizards, arsonists, and red dragons.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Findeladlara",
@@ -4755,7 +5304,6 @@
             "Edicts": "Preserve elven art and architecture, bless and secure households, inspire and aid others with your works",
             "Anathema": "Break the laws of hospitality, allow a guest to bring harm to your family",
             "Areas of Concern": "twilight and traditional art and architecture",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "cities",
                 "creation",
@@ -4769,7 +5317,13 @@
                 "7th:": "magnificent mansion"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ketephys",
@@ -4793,7 +5347,6 @@
             "Edicts": "Hunt and kill demons and undead, maintain the health of the forest, provide for your community",
             "Anathema": "Take more than needed from the wilderness, hunt an animal for sport, aid Treerazer or his minions",
             "Areas of Concern": "hunting and the moon",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "darkness",
                 "moon",
@@ -4807,7 +5360,13 @@
                 "3rd:": "animal vision"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Yuelral",
@@ -4833,7 +5392,6 @@
             "Edicts": "Practice herbalism, use and enchant gems, encourage and teach magicians and jewelers, preserve elven magic and knowledge",
             "Anathema": "Cut a gem for aesthetic purposes, defile nature, allow the irresponsible use of magic",
             "Areas of Concern": "gems, craft, and magic",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "creation",
                 "earth",
@@ -4853,7 +5411,13 @@
                 "9th:": "nature's enmity"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Andoletta",
@@ -4877,7 +5441,6 @@
             "Edicts": "Respect elders, instill good virtues in children, seek and allow redemption",
             "Anathema": "Hold a grudge, mock the dead, pass judgment hastily or carelessly",
             "Areas of Concern": "consolation, respect, and security",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "family",
                 "knowledge",
@@ -4891,7 +5454,13 @@
                 "(bird only), 6th:": "collective transposition"
             },
             "text": "Called Grandmother Crow, Andoletta represents consolation, respect, and security. Andoletta makes a clear distinction between guilt and innocence: there is no in-between. For those falsely accused or who show signs of redemption, she offers a path back to the light. That path is never an easy one, but it is one worth walking, and she stands beside those who make the trek. For the truly wicked and those who show no remorse, she has no mercy. For these reasons, her likeness is often found in courts, where she can watch over and ensure fairness to those accused of crimes. Andoletta also places great value on respect for the dead and the protection of children. To offer solace to the bereaved is true kindness and compassion. Children are slates with tremendous potential for good-if they can be guided and kept safe from evil. When she appears to mortals, Grandmother Crow does so as an older woman, gray-haired, wrinkled, and with keen, knowing eyes. She carries a walking stick and wears a cape of black crow feathers across her shoulders, giving the appearance of large, folded wings. Those who appeal to Andoletta include elders, the conflicted, the bereaved, the falsely accused, investigators, and judges.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Arshea",
@@ -4916,7 +5485,6 @@
             "Edicts": "Inspire passion, comfort and free the repressed, seek your true self and desires",
             "Anathema": "Judge another based on sexual desires or gender roles, harm another in pursuit of passion",
             "Areas of Concern": "freedom, physical beauty, and sexuality",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "confidence",
                 "freedom",
@@ -4930,7 +5498,13 @@
                 "5th:": "dreaming potential"
             },
             "text": "Appearing in art more than any of the other empyreal lords, the Spirit of Abandon represents freedom, physical beauty, and sexuality. More than anything else, freedom is what matters to Arshea. For many this is most commonly seen as freedom for sexual expression, but Arshea represents the freedom to experience all that is good in the world, be it an ideology or a specific emotional or physical expression. So long as it doesn't harm others, Arshea believes creatures should do, think, and feel as they will. They encourage their followers to try new things, to think in new ways, and to wear new forms. When appearing to mortals, the Spirit of Abandon most commonly appears in that person's own body so the person may see how beautiful and perfect their own form is-after all, if a divine being has chosen to wear it, it must be perfect. For people who don't fit in the body they currently wear, Arshea often appears in the form reflected in their heart and soul. Followers of Arshea are a varied lot, from artists to explorers, and from lovers to those who fight against repression.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Ashava",
@@ -4954,7 +5528,6 @@
             "Edicts": "Dance even when there is no music, cast light in places of darkness, lead the lost",
             "Anathema": "Intentionally mislead someone, desecrate graves, abandon a creature in darkness",
             "Areas of Concern": "moonlight, dancing, and lonely spirits",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "darkness",
                 "moon",
@@ -4968,7 +5541,13 @@
                 "8th:": "uncontrollable dance"
             },
             "text": "Ashava, the True Spark, embodies moonlight, dancing, and lonely spirits. Dancing is Ashava's true love, and she encourages her followers to dance often. For some, she is little more than a patron of that art, but Ashava is also a guide, both in spirit and in the physical world. For the living, she leads the lonely out of their difficult times, her lights guiding lost wanderers back to safety. For the dead, her haunting moonlit dances lead lost and lonely spirits onward to their eternal judgment. She encourages her followers to steer those who are lost-whether in the wilderness or in their hearts-to where they need to go. Priests of Ashava are the dancing light that guides the way, but will-o'-wisps are anathema to Ashava, and her followers destroy these creatures wherever they are found. The True Spark appears as a tall woman, flushed with the exertion of prolonged dancing. Her features are difficult to see unless under moonlight, when they instead become crystal clear. She wears a beautiful gown woven from starlight that always sways in motion, and she never appears to be standing still. On her brow she wears a wreath of many-colored moss. Some of Ashava's followers include dancers, artists, the nocturnal, the lonely, the bereaved, lovers, and travelers.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Black Butterfly",
@@ -4992,7 +5571,6 @@
             "Edicts": "Study the stars, notice moments of silence, perform anonymous acts of kindness",
             "Anathema": "Disrupt another's meditation, interrupt tranquil moments, play noisy or discordant music",
             "Areas of Concern": "distance, silence, and space",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "freedom",
                 "secrecy",
@@ -5006,7 +5584,13 @@
                 "4th:": "blink"
             },
             "text": "The Silence Between flutters among and between the stars, representing distance, silence, and space. Often called Desna's Shadow, the Black Butterfly is sometimes believed to be an aspect of Desna that has broken off and taken on its own life; her interest in distance and space certainly reflects Desna's love of travel. The Black Butterfly finds the silence of the sea of stars useful for introspection and learning about oneself. Those who follow her take opportunities when they can to sit in silent meditation, in zones of silence and darkness when possible. Travel across large distances offers plenty to think about and contemplate, and the Black Butterfly encourages such journeys. She hates all evil, but she truly despises the powerful beings of evil that populate the Dark Tapestry, and her followers are expected to fight these beings and their followers without mercy. The Silence Between manifests as the silhouette of a woman with butterfly wings, and white hair and eyes. Her wings contain a shadow-or reflection-of all of the Dark Tapestry and everything within it. Parted lovers, the isolated, the introverted, those who have sworn vows of silence or don't communicate verbally, stargazers, explorers, and the melancholy are all found among the followers of the Black Butterfly.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Cernunnos",
@@ -5030,7 +5614,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Protect forests and other natural areas, advocate for animals and plants, take and commit to decisive actions",
             "Anathema": "Fail to strike down evil, enable the destruction of wilderness, needlessly kill animals",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "lightning",
                 "nature",
@@ -5044,7 +5627,13 @@
                 "3rd:": "lightning bolt"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Dammerich",
@@ -5067,7 +5656,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Perform just executions, study local laws, oppose corrupt or bloodthirsty government officials",
             "Anathema": "Kill without thought, execute the innocent, mock the condemned, falsely incriminate another",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "death",
                 "duty",
@@ -5081,7 +5669,13 @@
                 "4th:": "stoneskin"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Eritrice",
@@ -5106,7 +5700,6 @@
             "Edicts": "Spread truth, debate contentious issues, aid messengers",
             "Anathema": "Sow or perpetuate lies, obstruct discussion, argue in bad faith",
             "Areas of Concern": "honest debate, opinions, and truth",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "confidence",
                 "glyph",
@@ -5120,7 +5713,13 @@
                 "3rd:": "enthrall"
             },
             "text": "The Heart-Speaker Eritrice represents honest debate, opinions, and truth. Facts and information are important to Eritrice, but truths and wisdom gained through discussion are far more valuable to her than those gained through books. She maintains there is nothing wrong with disagreeing so long as the disagreement is respectful, and that it is crucial to be open to discussion, willing to consider new information, and receptive to forming new opinions. Opinions are valuable in that they help understand other views, but Eritrice reminds her followers that opinions are not facts and can be incorrect and even harmful. When lies are spoken or become the rule of the land, those that follow Eritrice work through networks of like-minded individuals to spread the truth using messages sent to all who will listen. In her mortal form, the Heart-Speaker appears as a muscular, 8-foot-tall woman with a female lion's head. She wears a rose-colored breastplate over a short kilt. When she speaks, her voice is so entrancing and compelling that those she appears to often don't take note of any of her other features. Those who value truth, from debaters to town criers to lawmakers, are among the followers of Eritrice.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Falayna",
@@ -5145,7 +5744,6 @@
             "Edicts": "Wear and make beautiful things, train for combat, recover and return lost mementos",
             "Anathema": "Disrupt or destroy romantic unions, enforce a dress code, cower from fights",
             "Areas of Concern": "femininity, martial training, and rings",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "creation",
                 "freedom",
@@ -5159,7 +5757,13 @@
                 "5th:": "cloak of colors"
             },
             "text": "Femininity, martial training, and rings are the purview of the Warrior's Ring. In the eyes of Falayna, there is as much grace and beauty in the martial arts as exists in any culture's definition of femininity. The strength of womanhood is a hallmark of femininity, and strength in arms reflects this, with the flourish and personality of a fighting style a vibrant means for self-expression. Followers of Falayna learn to fight so they can both express their body and defend themselves if necessary, and strive to feel beautiful doing so, both in form and in dress. Falayna also enjoys rings, and as such she is associated with events in which rings are given or exchanged, such as weddings. When the Warrior's Ring appears to mortals, her form is most often that of a muscular woman with the hair and eye colors most commonly associated with feminine beauty in the mortal's mind. She wears a bright silver breastplate on top of flowing, silken robes, her longsword *Betrothal* sheathed across her back. On her fingers she wears rings of varying colors, styles, and stones; this jewelry seems to constantly shift, as if her fingers wear all the rings found in all the worlds. Followers of Falayna include warriors, soldiers, squires, jewelers, and those engaged to be married.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Halcamora",
@@ -5183,7 +5787,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Cultivate gardens, share wine, keep helpful insects, teach others to farm",
             "Anathema": "Salt or despoil the earth, spread plague or pestilence, carelessly use pesticides",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "indulgence",
                 "luck",
@@ -5197,7 +5800,13 @@
                 "4th:": "speak with plants"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Irez",
@@ -5223,7 +5832,6 @@
             "Edicts": "Read fortunes, practice calligraphy, devise and study runes",
             "Anathema": "Destroy magic scrolls, cheat at games of chance, deliberately write illegibly",
             "Areas of Concern": "glyphs, scribes, and spells",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "fate",
                 "glyph",
@@ -5237,7 +5845,13 @@
                 "3rd:": "secret page"
             },
             "text": "Cards, glyphs, scribes, and spells are all the purview of the Lady of Inscribed Wonder. She holds knowledge and understanding of the great power and symbolism behind runes. In particular, Irez understands how runes can supplement and empower arcane magic. It's through this understanding that Irez is able to make enigmatic predictions on events in the distant future, which more often than not come to pass. Many of her followers are calligraphers, gamblers, harrow readers and others who regularly handle cards and symbols, be they for an arcane purpose, prophetic practices, or their more mundane applications. Those who have seen Irez, either in person or through the cards, describe her as a woman with the body of a powerful serpent and large wings resembling those of a bat. Irez is constantly draped with strips of parchment, each bearing glyphs that bear the secret to a particular spell or specific cards, such as the harrow's Tyrant card.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Jaidz",
@@ -5262,7 +5876,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Forgive cowards and offer them guidance, encourage others to test their mettle, face and learn from your fears",
             "Anathema": "Punish another creature for cowardice, routinely avoid that which scares you",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "confidence",
                 "nightmares",
@@ -5276,7 +5889,13 @@
                 "7th:": "mask of terror"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Korada",
@@ -5300,7 +5919,6 @@
             "Edicts": "Forgive those who have wronged you, embrace a peaceful mindset, seek and allow redemption",
             "Anathema": "Cause lethal harm to a creature, deny a repentant creature an opportunity for redemption, ask a retired warrior to fight",
             "Areas of Concern": "foresight, forgiveness, and peace",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "change",
                 "healing",
@@ -5314,7 +5932,13 @@
                 "4th:": "resilient sphere"
             },
             "text": "Korada, the Open Hand of Harmony, is concerned with foresight, forgiveness, and peace. In particular, he believes that although the tireless fight against wickedness is admirable, the ultimate triumph over evil will come in the form of redemption rather than destruction. Korada's dedication to peace is such that he and his followers refuse to cause harm to their attackers, instead using their martial skills only to defend themselves. Many Koradans seek greater wisdom through study or meditation in hopes of better understanding their foes so as to guide them toward redemption. This dedication to self-awareness, philosophy, and introspection is said to have allowed Korada greater insight into the workings of the universe, granting him the great gift of foresight. Korada rarely acts on his visions, however, believing the struggle that comes with true change is always worthwhile, whether or not such a change is successful. The Open Hand of Harmony takes the form of a lithe, athletic man donning simple robes. He is covered in sparse, light-brown fur and has three monkey tails that constantly writhe behind him, much like the dancing flames of a powerful fire. Most of Korada's followers are those who have lived imbalanced lives or faced persistent violence as they seek to find peace in their life and within themselves. Many of the evil individuals redeemed by Koradans soon become followers themselves.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Lymnieris",
@@ -5338,7 +5962,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Help others achieve their desires, aid and protect sex workers, help others through difficult transitions",
             "Anathema": "Persecute sex workers, force or support unwanted marriages",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "change",
                 "passion",
@@ -5352,7 +5975,13 @@
                 "4th:": "resilient sphere"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Pulura",
@@ -5376,7 +6005,6 @@
             "Edicts": "Aid travelers, comfort the lonely, teach the constellations",
             "Anathema": "Mock the homesick, deny warmth to others, pollute the skies with smoke or light",
             "Areas of Concern": "constellations, homesickness, and northern lights",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "cold",
                 "darkness",
@@ -5390,7 +6018,13 @@
                 "6th:": "teleport"
             },
             "text": "Dancing through the northern sky, the Shimmering Maiden represents constellations, homesickness, and northern lights. Pulura understands that the constellations are the guide with which mortals navigate their world, lighting the way so that those who travel or explore can always find their way home. The stories of the constellations not only entertain with tales of goodness and light and strength, but they are also a tool for helping others learn and remember the stars. This ensures that the map in the sky is easy to read and never forgotten. To learn this map and to guide those who are lost or otherwise in need of direction are exceptional callings, but even more so is to teach a petitioner to navigate the skies themself on the journey. The Shimmering Maiden is often difficult to see, appearing to mortals from great distances as a bright, hot star. When she can be seen, she has the appearance of a Tian woman whose dark hair twinkles with bright stars. Her green and pink robes appear as though they are made of light, rather than any fabric. Travelers, guides, nomads, explorers, sailors, stargazers, and hunters are some of Pulura's followers.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ragathiel",
@@ -5414,7 +6048,6 @@
             "Edicts": "Avenge the wronged, destroy evildoers, lead the charge in battle",
             "Anathema": "Cower from combat, forgive those who have irreparably sinned, leave allies unwillingly in darkness",
             "Areas of Concern": "chivalry, duty, and vengeance",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "destruction",
                 "duty",
@@ -5428,7 +6061,13 @@
                 "4th:": "fire shield"
             },
             "text": "The General of Vengeance presides over chivalry, duty, and vengeance, acting as the quintessential knight. Born of the archdevil Dispater and Feronia, a neutral demigoddess of fire, Ragathiel struggles to overcome the reputation of his parentage, and he understands the struggle to be accepted, to be trusted, and to fight against his own nature for the sake of good. He represents strength in battle, wrath upon the wicked, absolution or vengeance for the wronged, leadership when needed, and virtue and duty to the innocent. He expects his followers to destroy fiends when they find them and to work toward truly earning the trust and acceptance of those around them. Those who follow him lead by shining example and can be found on the front lines of battle or any conflict against evil they can find. The General of Vengeance appears as a massive giant, standing more than 20 feet tall, clad in golden plate armor that shines with its own light and carrying a sword that burns with holy fire. Five flaming wings stretch from his back, three on his left and two on his right-the sixth was lost, torn out by his father in a fit of fury. Followers of Ragathiel include crusaders, knights, soldiers, the falsely accused, the marginalized, and the wronged.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Shei",
@@ -5452,7 +6091,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Empower local communities, learn from elders, share and teach from experiences",
             "Anathema": "Force others to follow your path, inflict negative damage, age others or steal life with magic",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "family",
                 "freedom",
@@ -5466,7 +6104,13 @@
                 "5th:": "dreaming potential"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Soralyon",
@@ -5492,7 +6136,6 @@
             "Edicts": "Study monuments, craft golems and artwork from stone, guard ancient sites",
             "Anathema": "Defile sacred buildings, knowingly unearth evil monuments, destroy historical artifacts",
             "Areas of Concern": "guardians, monuments, and magic",
-            "Divine Ability": "Strength or Intelligence",
             "domains": [
                 "creation",
                 "earth",
@@ -5506,7 +6149,13 @@
                 "4th:": "stoneskin"
             },
             "text": "Guardians, monuments, and magic are the purview of the Mystic Angel. Soralyon believes that monuments and ruins are important links to the past. Guarding them against those who would defile or destroy them is of tremendous importance, lest people lose memories of who they are, where they came from, and what they have accomplished. As such, those who stand guard over monuments and ruins are blessed. Likewise, those who study monuments to the past and present with respect, or seek to preserve them for the future, are also blessed. Guardianship of others, but especially of those who study and preserve these relics to the past, is also of great importance to Soralyon. As magic is a valuable tool in guarding, studying, and preserving these monuments and people, Soralyon encourages the study of magic, preferably for use in learning or protection. When the Mystic Angel appears to mortals he usually does so as a handsome being beautifully carved of smooth marble, the hues of which range the entire spectrum of the stone but tend toward those most common locally. Followers of Soralyon include archaeologists, historians, bodyguards, guardians, sculptors, curators, and arcane spellcasters.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Tanagaar",
@@ -5529,7 +6178,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Defend lawful borders, scout or patrol for evil, wait to strike until you have the advantage",
             "Anathema": "Abandon your post, tolerate poaching, torment animals",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "darkness",
                 "duty",
@@ -5543,7 +6191,13 @@
                 "4th:": "aerial form (bird only)"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Vildeis",
@@ -5567,7 +6221,6 @@
             "Edicts": "Sacrifice yourself in pursuit of good, champion noble causes, scar your body",
             "Anathema": "Joke or laugh about injustice, sacrifice others in your place, indulge in luxury",
             "Areas of Concern": "devotion, sacrifice, and scars",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "duty",
                 "pain",
@@ -5581,7 +6234,13 @@
                 "(appears as streams of blood), 5th:": "synaptic pulse"
             },
             "text": "The Cardinal Martyr presides over devotion, sacrifice, and scars. Vildeis is driven entirely by her abhorrence for evil. Evil should not and must not be allowed to exist. It should be fought without pause and without rest until it is completely and utterly destroyed. Not only does the fight never end, but every sacrifice that needs to be made to end evil must be made, and is worth making. There are no material rewards to be had for destroying evil-its destruction is all the reward necessary, and that reward can be enjoyed only once there is no more evil. Scars are the marks the fight leaves behind, the memory of all the sacrifices made. Vildeis expects total commitment from her followers, who leave everything behind and dedicate their lives to destroying all that is vile. The Cardinal Martyr appears as a human woman covered in scars, each forming a rune depicting a sacrifice she has made. Her eyes are covered in a red cloth so that she cannot see the horrors of evil upon the world. Vildeis flies on gigantic, blood-colored wings, and the whispered screams of all the planes' martyrs can be heard in her presence. Followers of Vildeis include martyrs, paladins, and zealots.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Winlas",
@@ -5605,7 +6264,6 @@
             "source": "Gods & Magic pg. 128",
             "Edicts": "Serve leaders of ceremonies, craft ceremonial arms and armor, lead a congregation",
             "Anathema": "Deride sacred ceremonies, carelessly or lazily perform rituals, destroy ceremonial objects",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "glyph",
                 "knowledge",
@@ -5619,7 +6277,13 @@
                 "4th:": "veil"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ylimancha",
@@ -5645,7 +6309,6 @@
             "Edicts": "Teach sustainable fishing, swim in saltwater, fly",
             "Anathema": "Imprison birds or clip their wings, poison coastal waters, overfish, aid Pazuzu or his minions",
             "Areas of Concern": "coastal waters, fishers, and flying creatures",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "air",
                 "nature",
@@ -5659,7 +6322,13 @@
                 "4th:": "fly"
             },
             "text": "Ylimancha gazes out over the world's coastlines, presiding over coastal waters, fishers, and flying creatures. Also known as Harborwing, she believes in harmony between the seas, the skies, and the beings of the land. Sustenance and resources can be taken from the sea by those on shore, but not so much that the balance is upset. The sea may sometimes encroach on the land, but breakwaters can be built to keep communities on land dry and safe. Ylimancha likewise loves all creatures that fly, though the demon lord Pazuzu also claims dominion over them, bringing the two into endless conflict and causing her to mourn deeply each creature he converts to his worship. Harborwing most often appears as a very large seagull, pure white in color with the head of a Varisian woman with short, dark hair. She sometimes instead appears as a human woman with the head of an osprey. In this form she wears robes that sway like the waves of the sea, their blue folds foaming white at the edges, and she carries a teak longbow strung with gold. When she speaks, her voice carries the sound of the crashing waves. Followers of Ylimancha include fishers, sailors, merfolk, those who make their living on or in the sea, and flying creatures.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Zohls",
@@ -5684,7 +6353,6 @@
             "Edicts": "Solve logic puzzles, investigate crimes, devise new solutions from research",
             "Anathema": "Make judgments without evidence, contaminate evidence, obstruct truths",
             "Areas of Concern": "determination, investigation, and truth",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "ambition",
                 "cities",
@@ -5698,7 +6366,13 @@
                 "7th:": "retrocognition"
             },
             "text": "Zohls, also known as Verity, advocates for determination, investigation, and truth. She believes that mysteries lead to truth, but how one arrives at that truth is as important as the answer itself. All questions are puzzles, and all puzzles are worth solving. The more intricate the problem, the more rewarding the investigation, and through determination and ethical investigation, even the deepest of enigmas can be solved. Calculated, logical thinking is more important to Zohls than gut instinct. She sees patterns everywhere, and she teaches that detecting these patterns brings the truth to light. While all investigations are worth pursuing so long as they don't hurt innocents, investigations that reveal the truth of crimes or other horrors, and that lead to justice being served and victims finding peace, are the most important of all to Verity. When appearing to her followers, Verity is always practically dressed, usually wearing a tunic and breeches. She wears black and white clothing, as these colors represent the light of truth and the darkness of obscurity and the unknown. She keeps her light-brown hair pulled back in braids. On her back she has large wings made of parchment that never wrinkle, whether furled or unfurled. Followers of Zohls include detectives, scientists, researchers, historians, archivists, librarians, and even conspiracy theorists.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Apollyon",
@@ -5723,7 +6397,6 @@
             "Edicts": "End all mortal life through disease and poison, cultivate diseased animals",
             "Anathema": "Prevent plagues, bury or burn the dead",
             "Areas of Concern": "disease",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "air",
                 "decay",
@@ -5737,7 +6410,13 @@
                 "5th:": "cloudkill"
             },
             "text": "The Prince of Plagues seized power for himself after the disappearance of the previous Horseman of Pestilence by obsessively eliminating all potential rivals. Apollyon commands his vast army of leukodaemons to spread oblivion like a virus. He wastes no time on trivial acts of violence and lacks the patience to wait for long-term schemes to come to fruition. Instead, his plagues carry oblivion through cities like lightning, decimating entire kingdoms in the span of a few days. His greatest creations have been diseases that corrupt the soul itself, ensuring that Pharasma sends his victims to Abaddon once they've succumbed. Apollyon appears as a hulking, bruised giant wrapped in black leather straps, with the head of a rotting ram. His cloak is stitched from the skin of angels who attempted to rescue the souls he had claimed-after flaying the angels alive, he preserved their faces in permanent agony upon the cloak. Apollyon delights in witnessing the deaths his diseases cause, not in dispassionate obligation but out of self-righteous glee. He sends his plague carriers out across the Material Plane knowing that even if they are defeated quickly, the sicknesses they carry will spread and take more lives than they could ever hope to alone. The moans and wails from the infected are prayers that fill him with more power to launch his next sickness onto the living.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Charon",
@@ -5762,7 +6441,6 @@
             "Edicts": "End all mortal life, exploit those who fear death",
             "Anathema": "Offer anything for free, extend mortal lifespans, grant true salvation to the doomed or dying",
             "Areas of Concern": "death",
-            "Divine Ability": "Constitution or Intelligence",
             "domains": [
                 "death",
                 "knowledge",
@@ -5776,7 +6454,13 @@
                 "9th:": "weird"
             },
             "text": "The First Horseman, eldest of his counterparts and the Boatman of the Styx, is a patient and cunning figure. Content to allow plans to take hold over time, Charon freely offers his power only to collect on his bargain decades or even centuries later. As the Horseman of Death, Charon concerns himself with miserable, pointless deaths that are devoid of any faith, mercy, or meaning, dragging those who perish in the depths of hopelessness and nihilism down into Abaddon and oblivion. Charon is the last surviving member of the original Horsemen who overthrew the First Daemon in their fit of jealous contempt. Holding knowledge from the earliest days of existence, he alone knows Abaddon's true history, but he keeps it to himself. This allows him to exploit opportunities with curious mortals, sweeping more souls into his dread kingdom. Charon appears as a tall, looming man dressed in a frayed cloak and gripping a lantern staff firmly in one hand, but it is widely believed that this form is a facade. His true face may be unknowable, hidden away at the end of the Styx within his sunken palace, the Drowning Court. Some theorize that this form is nothing more than a mouthpiece for a far more alien entity that lies beneath the waters of the Styx. Whatever the case, Charon is a timeless being whose bargains, promises, and bottomless hunger stretch back to the earliest days.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Szuriel",
@@ -5801,7 +6485,6 @@
             "Edicts": "End all mortal life through war, obliterate faith",
             "Anathema": "Show mercy to creatures who do not worship Szuriel, choose to marry or have children",
             "Areas of Concern": "war",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "ambition",
                 "destruction",
@@ -5815,7 +6498,13 @@
                 "4th:": "weapon storm"
             },
             "text": "All Szuriel has ever known is war. In life she was first a paladin, then excommunicated from her church for heresy. In response, she slaughtered her way to power until she was crowned empress, then subsequently had every member of her former faith crucified. She went on to wage several brutal wars against neighboring kingdoms until an assassin's dagger found her heart. Sent to Abaddon, she rose quickly through the ranks of daemonkind, and when she saw weakness in the Horseman of War, she slew him in battle, claiming his title for herself. Szuriel appears as a tragic angel with beautiful golden hair, magnificent wings, and polished obsidian eyes that continuously weep blood. She resides in the Cinder Furnace, her corner of Abaddon where instruments of war are forged from the fires of burning souls. Szuriel commands one of the largest standing armies in all of existence, countless daemonic soldiers ready to wage war. All fear oblivion at the hands of Szuriel and her army. The Horseman of War is always happy to lend her powers, warriors, and devastating discoveries across the planes. So long as war continues, more souls are pulled into her ever-burning furnace.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Trelmarixian",
@@ -5840,7 +6529,6 @@
             "Edicts": "End all mortal life through wasting consumption and starvation, violently consume matter and souls",
             "Anathema": "Kill or remove a parasite or tumor, grow food",
             "Areas of Concern": "famine",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "decay",
                 "dust",
@@ -5854,7 +6542,13 @@
                 "5th:": "acid storm"
             },
             "text": "Before his mortal death, Trelmarixian had already destroyed an entire world. Born a daemonic-blooded tiefling, his hatred of those around him was an all-consuming hunger, and he never knew peace. During an eclipse, he performed a ritual so powerful it mummified every living creature on his world, and his heart was finally full. Dying from starvation but elated by his success, Trelmarixian heard a voice call out to him. The voice mocked him, exclaiming all he'd accomplished was insignificant compared to what awaited him next. Trelmarixian's last mortal memory was of staring into an eclipse. Lyutheria, the original Horseman of Famine, was impressed by Trelmarixian's conquest and took him on as her apprentice, fatally underestimating his ambitions. After Trelmarixian learned all he could from his master, he devoured her and assumed her title. Trelmarixian appears as sickly man with three snapping jackal heads and putrid, membranous flesh that is constantly dripping and sloughing off his body. As the Horseman of Famine, Trelmarixian ushers in oblivion slowly, watching mortals waste away as their bodies turn against them. He spreads cancer by touch, inciting cells to rebellion, and his breath causes outbreaks of hives and asthma attacks in those nearby. He aligns himself with Szuriel to see that soldiers never make it home to reap their fields, leaving crops to rot on the vine. He collaborates with Apollyon to spread diseases from livestock, rendering butchers' larders barren. Trelmarixian has little trust for Charon, however, certain that the oldest Horseman is hiding secrets.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Barzahk",
@@ -5879,7 +6573,6 @@
             "Edicts": "Aid travelers and those who return from the dead, tend to roadside graves, find missing objects or people",
             "Anathema": "Celebrate specific calendar dates over others, avoid travel or change, freeze time for an object or creature",
             "Areas of Concern": "compasses, travelers, and vigils",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "death",
                 "knowledge",
@@ -5893,7 +6586,13 @@
                 "6th:": "teleport"
             },
             "text": "Appearing as an enormous migratory bird-usually a corvid, but sometimes a songbird-draped in robes and carrying a tombstone lock and a giant bone key, Barzahk the Passage is the psychopomp usher who maintains the Dead Roads, the secret back routes between the planes and the mortal world. Among mortals, they are worshipped as a patron of compasses, travelers, and vigils. Barzahk is tasked with transporting the souls of those who die far from home to ensure that they reach their proper destination. Unfortunately, Barzahk wanders far and wide, and so they rarely attend to this duty. Thus his followers, both psychopomps and mortals, take it upon themselves to care for lost souls, both literal and figurative. Like their patron, followers of Barzahk are often migratory, helping those they find along the way.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Chohar",
@@ -5918,7 +6617,6 @@
             "Edicts": "finish any and all tasks you accept, bring those who are cruel to justice, show pride in your home and your heritage",
             "Anathema": "break your word, be cruel to the innocent, rebuke someone due to their homeland",
             "Areas of Concern": "justice, loyalty, and work",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "cities",
                 "family",
@@ -5937,7 +6635,13 @@
                 "4th:": "fire shield"
             },
             "text": "The Lion God of justice, loyalty, and work. He is most commonly depicted as a golden lion with a sun for a mane. Some priests of Walkena claim that the child god is a descendant of Chohar, because of their shared love of justice-yet Walkena's justice is vindictive and cruel, while Chohar's is one of duty.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Imot",
@@ -5962,7 +6666,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Search for omens in the natural world, push the boundaries of mathematics, study past disasters",
             "Anathema": "Withhold your understanding of a portent, prevent the destruction of things that cannot be saved",
-            "Divine Ability": "Strength or Intelligence",
             "domains": [
                 "death",
                 "destruction",
@@ -5976,7 +6679,13 @@
                 "6th:": "phantasmal calamity"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Kerkamoth",
@@ -6001,7 +6710,6 @@
             "Edicts": "Clean cluttered spaces, embrace moments of silence",
             "Anathema": "Attempt to preserve something indefinitely, perform an act of wanton and significant destruction",
             "Areas of Concern": "emptiness, entropy, and stillness",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "darkness",
                 "decay",
@@ -6015,7 +6723,13 @@
                 "6th:": "disintegrate"
             },
             "text": "Also known as the Waiting Void, the unseen Kerkamoth is the primordial inevitable of emptiness, entropy, and stillness. Though many people view decay and entropy as manifestations of chaos, followers of Kerkamoth understand that in an orderly universe, the end of one cycle makes way for the beginning of a new cycle. These worshippers track such transitions and work to properly dispose of those things that have outlived their usefulness, whether it's cleaning a cluttered closet or demolishing an old building. Yet, Kerkamoth opposes those who destroy with abandon and no greater purpose, which often brings them in conflict with daemons, demons, and proteans. Though they favor areas of emptiness and silence to commune with their patron, worshippers of Kerkamoth recognize that these too cannot last forever, inevitably to be filled with new creations.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Luhar",
@@ -6040,7 +6754,6 @@
             "Edicts": "learn about the night and prepare yourself to face its creatures and dangers, always make time for sleeping and dreams, ensure others never go to sleep scared",
             "Anathema": "stay up all night without any breaks for sleeping or dreaming, attack a person or creature while they sleep, leave a badly wounded opponent alive and suffering",
             "Areas of Concern": "death, dreams, and destiny",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "cities",
                 "darkness",
@@ -6059,7 +6772,13 @@
                 "5th:": "shadow walk"
             },
             "text": "The Lioness Goddess of death, dreams, and destiny. She is most commonly depicted as a lioness with the head of a human woman, dark skinned with bright eyes.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Monad",
@@ -6084,7 +6803,6 @@
             "Edicts": "Ensure balance between opposing forces, mediate disagreements",
             "Anathema": "Allow your personal motivations to determine a major decision",
             "Areas of Concern": "creation, the infinite, and truth",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "creation",
                 "knowledge",
@@ -6098,7 +6816,13 @@
                 "4th:": "gaseous form"
             },
             "text": "All aeons come from, return to, are connected with, and are guided by the Monad. The Condition of All is not a deity in the traditional sense. It exists both within and outside the multiverse and has influence over the entirety of existence. Though generally content to allow the multiverse to run its course, the Monad directs its aeons to intervene when events deviate from their ineffable design. Mortal scholars often personify the Monad as the deity of creation, the infinite, and truth. Even so, few worship it, and the Monad pays very little attention to mortal petitioners. Instead, scholars study and plot aeons' actions, striving to discern the Monad's ultimate goal or to uncover universal truths they can exploit for their own purposes. Only a rare few mortals can master the asceticism necessary to connect with the Monad, gaining hidden knowledge and powers akin to those of other divine spellcasters.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Mother Vulture",
@@ -6123,7 +6847,6 @@
             "Edicts": "Recycle rot and waste into useful creations, eat the flesh of your own people, kill without mercy if it benefits your community, help to raise children",
             "Anathema": "Poison insects or scavengers, waste food or good materials, allow rot to poison an area, create undead",
             "Areas of Concern": "consumption, renewal, and transformation",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "change",
                 "death",
@@ -6137,7 +6860,13 @@
                 "6th:": "baleful polymorph"
             },
             "text": "Though she usually appears as a blind young woman, in her natural form the Flesheater is an enormous, bloated creature with four wings and two long necks topped with masked heads and gaping maws. Mother Vulture reflects the dualistic process of decay. She is a vicious killer whose feasts stain the ground, representing the death inherent in decay, but also a thoughtful mother, representing the new life that can take root in the fertile soil left in the wake of destruction. Mother Vulture's mortal worshippers, who often dwell in deserts and swamps, revere her as the patron of consumption, renewal, and transformation. In this last aspect, she judges those souls who sought redemption in life, deciding whether their atonement was sufficient to avoid an undesired afterlife.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Narakaas",
@@ -6161,7 +6890,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Help others through painful changes, offer harsh punishments to the penitent, seek and allow redemption",
             "Anathema": "Torture an unwilling creature, take joy in suffering",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "change",
                 "death",
@@ -6175,7 +6903,13 @@
                 "4th:": "modify memory"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Narriseminek",
@@ -6200,7 +6934,6 @@
             "Edicts": "Divine the future, transform the bodies of willing creatures, rebel against organized structures",
             "Anathema": "Refuse to speak to a keketar, eschew a challenge by turning down a promotion or an advancement",
             "Areas of Concern": "ascendance, keketars, and revelations",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "delirium",
                 "freedom",
@@ -6214,7 +6947,13 @@
                 "5th:": "synesthesia"
             },
             "text": "Called the Crownless and the Maker of Kings, Narriseminek often appears as a protean with a scar around their pate, as if left by a burning crown. Their true form, though similar, is rarely seen: an iridescent and golden protean with a halo of burning eyes but empty eye sockets. The protean lord of ascendance, keketars, and revelations rarely interacts with non-proteans, but to their protean worshippers, they offer exalted transformations and revelations that can change a being's entire outlook. Worshippers of Narriseminek, both mortal and protean, spend their time divining the future and using magic to transform their bodies-a practice they also extend to any other willing creatures who ask. Their revelations take the form of patterns emerging in otherwise random events; Narriseminek's followers reject astrology and other forms of divination based on predictable cycles.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Otolmens",
@@ -6238,7 +6977,6 @@
             "Edicts": "Relentlessly document and interpret data, correct cosmic errors",
             "Anathema": "Suppress a factual report, ignore facts, misrepresent quantitative data",
             "Areas of Concern": "machinery, math, and physics",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "creation",
                 "fate",
@@ -6252,7 +6990,13 @@
                 "7th:": "reverse gravity"
             },
             "text": "The primordial inevitable of machinery, math, and physics, Otolmens the Universal is tasked with keeping the galaxies, stars, planets, and other heavenly bodies moving in their proper orbits. From her observatory in the city-plane of Axis, Otolmens and her myriad axiomite assistants track the motions of these objects on the Material Plane. When an anomaly is discovered, Otolmens dispatches inevitables to correct the problem. A mechanical being with multiple heads and limbs, Otolmens is said to spin like an orrery when in a flurry of activity. Her mathematical precision is revered by engineers and scientists, who form the core of her worship. Most pray to her hoping to receive divine inspiration or to stave off inaccurate calculations, but she may call upon her more powerful worshippers to fight threats to the very planet they inhabit.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Saloc",
@@ -6277,7 +7021,6 @@
             "Edicts": "Help creatures grow and find purpose, offer second chances to failures, study different perspectives on ethics",
             "Anathema": "Manipulate or remove a creature's emotions with magic, spread nihilism or hopelessness",
             "Areas of Concern": "agency, bronze, and education",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "change",
                 "death",
@@ -6291,7 +7034,13 @@
                 "5th:": "dreaming potential"
             },
             "text": "Ruler of the planar metropolis of Spire's Edge in the Boneyard, the psychopomp usher Saloc is humanoid, but their face is devoid of features save stag horns, and two golden rings lined with eyes constantly rotate about their body. As a defense counsel in Pharasma's court, the Minder of Immortals argues that a person's intentions should be considered in equal part to the consequences of their actions when deciding their soul's afterlife. Saloc has even been known to resurrect condemned souls to give them a second chance to prove themselves. Mortals revere Saloc as the patron of agency, bronze, and education. These followers are people who seek to improve themselves or others, including both students and teachers. Some seek to earn their freedom from earthly prisons, while others wish to change their ways to avoid punishment in the hereafter.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Tlehar",
@@ -6316,7 +7065,6 @@
             "Edicts": "give yourself fully to everything you attempt, always maintain hope that tomorrow will be a better day, treasure every gift you are given by those who matter to you",
             "Anathema": "lose your motivation to your regrets, spread despair, treat a loved one poorly",
             "Areas of Concern": "iron, love, and rebirth",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "cities",
                 "healing",
@@ -6335,7 +7083,13 @@
                 "5th:": "dreaming potential"
             },
             "text": "The Lioness Goddess of iron, love, and rebirth. She is most commonly depicted as human but with the head of a lioness, her fur a dull gray and her eyes black as night.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Valmallos",
@@ -6360,7 +7114,6 @@
             "Edicts": "Complicate magical techniques, refine arcane fundamentals, teach arcane apprentices to treat magic responsibly",
             "Anathema": "Grant magic to those who cannot use it responsibly, cause a magical disaster, ignore magical misconduct",
             "Areas of Concern": "ceremonies, magic, and preparation",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "fate",
                 "glyph",
@@ -6374,7 +7127,13 @@
                 "7th:": "contingency"
             },
             "text": "The Answering Rite is the primordial inevitable of ceremonies, magic, and preparation. Valmallos takes the form of a mechanical giant, his chest open to expose a glowing heart, with scrolls swirling about him like serpents. Valmallos understands all the laws of magic, and sends his agents against those who have acquired magical ability that they have neither earned nor have the discipline to control. Many scholars of magic believe Valmallos is at least partly responsible for the complex material, somatic, and verbal components necessary to perform magic. His followers are spellcasters who seek perfection in the performance and effects of their magic. Though willing to teach magic to others, they cloak their techniques in layers of ritual to weed out those who lack the patience to handle magic properly.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ydajisk",
@@ -6401,7 +7160,6 @@
             "Edicts": "Create using words, chronicle languages and prevent them from dying, help language evolve",
             "Anathema": "Ban or discourage a language, explain a secret language or slang to outsiders, destroy literary works",
             "Areas of Concern": "language evolution, lost words, and slang",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "change",
                 "glyph",
@@ -6415,7 +7173,13 @@
                 "4th:": "glibness"
             },
             "text": "The protean lord of language evolution, lost words, and slang, Ydajisk manifests as a protean with six arms and a cobra's hood, surrounded by a cloud of drifting sounds, symbols, shapes, and myriad other sensory experiences that shift endlessly in and out of existence. Closer inspection reveals that their body is made from interlacing strands of poetic protean script. Ydajisk is also called the Mother of Tongues, though like all proteans, their gender changes as they will. Followers of Ydajisk are wanderers, reviving dead languages from ancient ruins, chronicling the dying tongues of cultures in decline, and discovering or inventing new words. All such knowledge acquired by agents of the Mother of Tongues passes into Ydajisk's realm, the Library of Stolen Words, where it is transcribed into books or stored in magical containers, alongside scrolls and tomes considered long lost by mortal scholars.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Azathoth",
@@ -6438,7 +7202,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Gather a court of devotees, create discordant piping or babbling",
             "Anathema": "None",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "decay",
                 "destruction",
@@ -6452,7 +7215,13 @@
                 "9th:": "unfathomable song"
             },
             "text": "Azathoth is the Daemon Sultan and the Primal Chaos, a roiling mass of destructive and transformative power the size of a sun, dwelling in the darkness between the stars, deep in the center of the universe. There, masked from mortal sight by a veil of swirling colors, he is surrounded by the other Outer Gods that make up his court, dancing and cavorting about him endlessly, filling the void with the sound of ghastly flutes. Azathoth is utterly unaware of and uncaring toward those few who have come to revere and worship him. It is precisely this blind, uncaring nature that makes Azathoth the perfect embodiment of a blind, uncaring universe. Azathoth's name, however, has great power over the Outer Gods when properly invoked. He has also sometimes been summoned by mortal priests-and though these summons attract only a tiny sliver of his attention and manifest as a form other than that of the Primal Chaos, they nevertheless lead to destruction on a massive scale.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Hastur",
@@ -6475,7 +7244,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Spread Hastur's Yellow Sign, hide the true nature of your worship, promulgate the play The King in Yellow",
             "Anathema": "None",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "glyph",
                 "secrecy",
@@ -6489,7 +7257,13 @@
                 "5th:": "hallucination"
             },
             "text": "Hastur is a Great Old One who, though confined to the city of Carcosa on a planet orbiting a faraway star, is nevertheless in the midst of a transformation into a true Outer God. He works toward this feat through his avatar, the King in Yellow, which can manifest anywhere in the universe the light from Carcosa's sun can be seen. The King in Yellow appears as a humanoid figure draped in yellow clothing, but there is nothing within the clothes save a shapeless, horrifying presence. Hastur himself is also referred to as Him Who Is Not To Be Named, or simply the Unspeakable. Self-indulgence and nihilism are at the heart of Hastur's worship, and he is popular among debauched artists and nobles who recognize no purpose to life other than gratifying their own increasingly grotesque and outlandish tastes. Cults of Hastur are united in their use of the Yellow Sign, a triskelion design that allows Hastur to observe and possess those who gaze upon it. The presence of the Yellow Sign among a city's graffiti is a foreboding indication that Hastur's attention has been drawn there, and these settlements soon find themselves under attack either by Hastur himself-who seeks to draw cities into Carcosa, fueling his transformation into an Outer God-or by Xhamen-Dor, a parasitic deity spawned by Hastur as he walked Carcosa's sewers.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Nhimbaloth",
@@ -6511,7 +7285,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Create undead, feast upon carnivores that have recently feasted upon others",
             "Anathema": "None",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "decay",
                 "nature",
@@ -6525,7 +7298,13 @@
                 "5th:": "cloudkill"
             },
             "text": "An especially reclusive Outer God who hunts along the shores of the River of Souls, Nhimbaloth is a shapeless entity known as the Empty Death. She preys on those who hunt souls as they travel down the river, but she devours both hunter and soul indiscriminately; those she consumes have no afterlife or potential for resurrection. They are forever gone, and forever nothing. Nhimbaloth is said to see through will-o'-wisps, and her trace is left behind in a symmetrical pattern of seven divots along the shoreline, said to be her fingerprints. Faceless undead haunt the places where she has passed, and plant and animal life in the area is especially hostile to the living. One place where she has particular influence is within the Mushfens of southern Varisia, where will-o'-wisp oracles sap the drive and reason from their victims and leave them wandering in a vacuous stupor through the blasted swamp.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Nyarlathotep",
@@ -6548,7 +7327,6 @@
             "source": "Gods & Magic pg. 130",
             "Edicts": "Sow discord among allies, misuse positions of authority by steering events toward apocalyptic ends",
             "Anathema": "None",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "knowledge",
                 "magic",
@@ -6568,7 +7346,13 @@
                 "9th:": "weird"
             },
             "text": "Nyarlathotep is a being of a thousand shapes, each of which has a name, such as the Haunter of the Dark or the Black Pharaoh. Because he has walked the world in mortal form, Nyarlathotep is unique among the Outer Gods for appearing comprehensible and understandable-but this is a facade. The Crawling Chaos, as he is also known, appears humanlike not because he identifies with mortal concerns or cares for his mortal followers, but because a mortal shape makes it easier for him to do his work: spreading the influence of the Outer Gods. In his role as a herald, messenger, and agent provocateur for the Outer Gods, Nyarlathotep is the Outer God most likely to have direct interactions with mortals. He answers prayers, teaches evil magic, and inserts himself into history-all to enable mortal cruelty, facilitate the release of Great Old Ones, and turn whole societies toward worship of the Outer Gods. He was instrumental in the fall of Ancient Osirion, and some believe he led Taldor to launch the Armies of Exploration, a glorious folly that proved the ruin of that empire. There are countless tales of his interaction with (and often possession of) mortal cultists and magicians who dare to call upon him, and they all end in grotesque corruption and death. Nyarlathotep also lingers among Azathoth's court, carrying out schemes under the guise of the Primal Chaos's will.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Xhamen-Dor",
@@ -6591,7 +7375,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Spread fungal growths, subtly infect others with knowledge of Xhamen-Dor",
             "Anathema": "None",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "change",
                 "decay",
@@ -6605,7 +7388,13 @@
                 "7th:": "warp mind"
             },
             "text": "Xhamen-Dor, the living cancer, was born in the sewers beneath Carcosa, the alien city that is the home of Hastur. Somehow, this Great Old One was transported to Golarion within a comet, crashing into the bottom of a lake during the devastation of Earthfall. Physically, it manifests as a twisting and vaguely serpentine-shaped mass of bone, hair, and fungus. The Inmost Blot, as Xhamen-Dor is also known, exists to conquer worlds by infecting the living with itself. Its victims, the seeded, enact its will and seek to spread its influence until the entire world is just an extension of Xhamen-Dor itself. Then, once only the seeded remain, Xhamen-Dor uses the last of the planet's energy to return to Carcosa, which in turn absorbs the world Xhamen-Dor has brought to it, allowing Carcosa to slowly grow.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Yog-Sothoth",
@@ -6628,7 +7417,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Gather knowledge of gates through space and time, curse or mutate unborn children",
             "Anathema": "None",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "knowledge",
                 "time",
@@ -6642,7 +7430,61 @@
                 "7th:": "time beacon"
             },
             "text": "Yog-Sothoth is, along with Azathoth, one of the greatest of the Outer Gods. In appearance, he is said to be a congeries of iridescent spheres-brilliant, foaming bubbles that constantly expand and collapse in upon themselves. He has other manifestations, however, including the Lurker on the Threshold, a mass of black tentacles that endlessly writhe, reach, and grow, and a mysterious humanoid figure hidden behind a shimmering veil. Yog-Sothoth embodies all of space and time; he exists in all places and in all moments simultaneously. Paradoxically, however, he is unable to manifest in the mortal universe unless summoned, a magical act that almost always results in untold destruction. He is known as the Key and the Gate, and magicians and cults research him in an effort to master time and space. Fortunately, his worship is not widespread, but some of those who have delved deep into his secrets describe him as an ambivalent figure, rather than a malevolent one, who guards cosmic secrets and makes them accessible to those who dare to ask for them. Yog-Sothoth reveals the true nature of the universe, but this is a thing that once seen cannot be unseen, and wise mortals turn aside from Yog-Sothoth's offer of cosmic knowledge in favor of a more mundane existence.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
+        },
+        {
+            "name": "Cosmic Caravan",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=219",
+            "PFS": "No PFS Data",
+            "category": "Pantheons",
+            "alignment": [
+                "CG"
+            ],
+            "followerAlignments": [
+                "NG",
+                "CG",
+                "CN"
+            ],
+            "font": [
+                "harm",
+                "heal"
+            ],
+            "weapon": [
+                "starknife"
+            ],
+            "source": "Abomination Vaults Player's Guide pg. 5",
+            "Edicts": "spend time stargazing or meditating in moonlight, aid those who live in regions where Zon-Kuthon (or other religions that espouse the night as a bastion for evil) hold sway, help the desperate or forlorn to see potential for a better life in the future, travel with no particular destination in mind",
+            "Anathema": "portray the night as a time of evil, destroy astronomical or astrological equipment, spend the night in the same place twice in a row",
+            "Areas of Concern": "constellations, fortune telling, the night, hope for a better tomorrow",
+            "domains": [
+                "darkness",
+                "fate",
+                "freedom",
+                "moon"
+            ],
+            "altDomains": [
+                "star",
+                "void"
+            ],
+            "clericSpells": {
+                "1st:": "object reading",
+                "2nd:": "glitterdust",
+                "6th:": "blanket of stars"
+            },
+            "text": "The Cosmic Caravan is known to astronomers and astrologers alike as a collection of constellations in the sky, said to travel forever in a circle around the star Cynosure. The association of a diverse array of gods and demigods thematically linked with the stars and the spaces between is a relatively new faith that first rose to prominence in western Avistan, particularly in Varisia, Nidal, and Ravounel. The deities worshiped by the faithful of the Cosmic Caravan include: Desna, Groetus, and Sarenrae; the empyreal lords Ashava, Black Butterfly, and Pulura; the elven god Ketephys; and the outer god Yog-Sothoth. This faith has been gaining ground particularly in Nidal, where the worship of the night is overwhelmingly associated with Zon-Kuthon, and a rising number of Cosmic Caravan worshipers seek to oppose or, one day, even overthrow the Midnight Lord's theocracy to reclaim the night from the implications that all who dwell in the dark are evil.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Dwarven Pantheon",
@@ -6669,7 +7511,6 @@
             "Anathema": "dishonor your family, willingly break a contract or oath, irreparably damage an ancestral relic",
             "Areas of Concern": "ancestry, crafting, dwarves, relationships",
             "Pantheon Members": ", , , , , , , ,",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "creation",
                 "family",
@@ -6686,7 +7527,13 @@
                 "7th:": "retrocognition"
             },
             "text": "The dwarven gods are one large family, with Torag as its patriarch. He is joined by his brothers Magrim (the Taskmaster) and Angradd (the Forge Fire), his half-sister Dranngvit (the Debt Minder), and his wife Folgrit (the Watchful Mother). His children are Bolka (the Golden Gift), Grundinnar (the Peacemaker), Kols (the Oath-Keeper), and Trudd (the Mighty). Torag's evil former student Droskar (the Dark Smith), though technically part of the dwarven pantheon, is rarely invoked by any save duergars.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Elven Pantheon",
@@ -6713,7 +7560,6 @@
             "Anathema": "irreparably damage the natural environment (such as by overhunting or strip mining), have an unhealthy obsession or attachment",
             "Areas of Concern": "elves, magic, nature, tradition",
             "Pantheon Members": ", , , ,",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "creation",
                 "magic",
@@ -6727,7 +7573,13 @@
                 "5th:": "tree stride"
             },
             "text": "The traditional deities of the elven pantheon are Calistria, Desna, Findeladlara (goddess of twilight and traditional art and architecture), Ketephys (god of hunting and the moon), and Yuelral (goddess of gems, craft, and magic). Elves have also adopted Alseta, a minor goddess of doors and transitions, as their patron of teleportation and aiudara (commonly known as elf gates). Most elves value magic, beauty, freedom, and friendship as part of a fulfilling life and tend to worship all of the deities together as exemplars of these values. Alongside full-blooded elves, many half-elves-whether raised by elves or seeking a closer connection to their elven heritage- worship the elven pantheon.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Pillars of Knowledge",
@@ -6754,7 +7606,6 @@
             "Anathema": "Choose to use old knowledge or tools after they have been improved upon, destroy knowledge, refuse to answer a query for which you know the answer",
             "Areas of Concern": "Learning, innovation, safeguarding knowledge",
             "Pantheon Members": ", , ,",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "creation",
                 "knowledge",
@@ -6772,7 +7623,13 @@
                 "9th:": "retrocognition"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "The Godclaw",
@@ -6799,7 +7656,6 @@
             "Anathema": "rest when there is lawlessness to fight, believe you know or understand more than the pantheon",
             "Areas of Concern": "discipline, laws, order, strategy",
             "Pantheon Members": ", , ,",
-            "Divine Ability": "Strength or Intelligence",
             "domains": [
                 "perfection",
                 "protection",
@@ -6815,7 +7671,13 @@
                 "6th:": "dominate"
             },
             "text": "The Hellknight Order of the Godclaw reveres a pantheon of five deities: Iomedae and Torag are seen as Hellknights (concerned with offensive and defensive combat, respectively), Irori as the epitome of emotionless discipline, Abadar as a keeper of laws, and Asmodeus as a strategist king. Depictions of these deities as part of the Godclaw differ from traditional images, with the deities portrayed as stern, armored paragons of law. Though some members of the Order of the Godclaw dedicate themselves to individual gods, many take the whole pantheon as their patron, receiving spells despite their unorthodox (perhaps even heretical) beliefs.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "The Path of the Heavens",
@@ -6841,7 +7703,6 @@
             "Anathema": "mislead a traveler, permanently blind an enemy",
             "Areas of Concern": "Celestial bodies, navigation, travelers",
             "Pantheon Members": ", ,",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "moon",
                 "star",
@@ -6858,7 +7719,13 @@
                 "3rd:": "gravity well"
             },
             "text": "The Path of the Heavens is well known to those who make their way in Golarion. Looking down from above, these deities help travelers and voyagers find their path. Their guidance can be literal, or for others, more spiritual-some worshippers seek to know the progress of Sarenrae (the sun), Tsukiyo (the moon), and Desna (the stars) and through this knowledge gain enlightenment. Nocticula, the last member of the pantheon, for her part uses the cover of the darkness, the gaps in between the others, to shelter travelers and outcasts. Some who worship her as their primary deity in the pantheon seek to use the void between the stars to defend voyagers on the road. Though this is frowned upon by the other members of the Path of the Heavens, it does not seem to disrupt the harmony between the gods.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "The Prismatic Ray",
@@ -6884,7 +7751,6 @@
             "Anathema": "allow evil to spread, destroy that which brings joy to others, fail to offer evil a chance to surrender",
             "Areas of Concern": "Defeating evil, guarding innocents, and wholesome creations",
             "Pantheon Members": ",",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "creation",
                 "moon",
@@ -6902,7 +7768,13 @@
                 "4th:": "creation"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Wards of the Pharaoh",
@@ -6930,7 +7802,6 @@
             "Anathema": "Destroy wards that are actively protecting innocents, refuse to use your magic to help those in need who ask you",
             "Areas of Concern": "Abjuration magic, protection, self-improvement",
             "Pantheon Members": ", ,",
-            "Divine Ability": "Constitution or Intelligence",
             "domains": [
                 "family",
                 "knowledge",
@@ -6947,7 +7818,13 @@
                 "9th:": "disjunction"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Ardad Lili",
@@ -6971,7 +7848,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Manipulate others with false promises, aid women who have been unfairly maligned",
             "Anathema": "Give someone more than you receive from them, allow yourself to be swayed by lust",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "creation",
                 "darkness",
@@ -6985,7 +7861,13 @@
                 "4th:": "suggestion"
             },
             "text": "When mortals were young, before Asmodeus conquered Hell, Ardad Lili was already manipulating amorous and lustful mortals to swear fealty to her, amassing power from their souls. She fled the realm of Nirvana during the Exodus, taking up residence in Avernus and continuing to gather an army of damned souls and female devils who share her ambitions. The Serpent Muse has never forgotten the censures and cruel insults spewed by the other natives of Nirvana, and she seeks to someday rule not a layer of Hell, but a realm of the heavens. Herself a passionate being, she draws similarly passionate followers.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Doloras",
@@ -7008,7 +7890,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Push the boundaries of science and suffering, torture other creatures",
             "Anathema": "Show or act on emotion, allow a plea for mercy to sway you",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "creation",
                 "pain",
@@ -7022,7 +7903,13 @@
                 "5th:": "synaptic pulse"
             },
             "text": "Perhaps the cruelest of Hell's divinities, the Sadistic Angel shares certain characteristics with the velstracs who once resided in Hell-most notably, a drive to inflict physical pain upon living creatures. She does not inflict her torments out of anger or retribution; she practices her art with an unparalleled detachment and absence of emotion. Her followers are sadists, torturers who relish their grisly work, and those diabolists who summon velstracs rather than devils. While she bears the title of Queen of the Night and commands power commensurate with the others, Our Lady in Pain is content with her station and holds no ambitions beyond ensuring she can continue her tortures uninterrupted.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Eiseth",
@@ -7044,7 +7931,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Avenge all insults, claim what you desire and deserve, humiliate your foes in ironic fashion",
             "Anathema": "Allow a slight to go unanswered, show humility or fear",
-            "Divine Ability": "Strength or Dexterity",
             "domains": [
                 "ambition",
                 "destruction",
@@ -7058,7 +7944,13 @@
                 "4th:": "dimension door"
             },
             "text": "Hell's Valkyrie rules a domain spanning part of Dispater's realm, commanding her legions of erinyes and executioner devil soldiers as she sees fit. Eiseth operates outside Dispater's rule, and she has forged powerful alliances with those in Hell and beyond, having long ago rejected limitations placed upon her by others. Foremost among the Queens of the Night, she embodies battle, revenge, and wrath, and her ambitions are as lofty as her aerie of Widow's Cry, where she forges souls of the damned into unequaled infernal legions answering to her alone.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Mahathallah",
@@ -7082,7 +7974,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Become an arbiter of reality, reject conventional wisdom as falsehood, capitalize on the ignorance of others",
             "Anathema": "Become too invested in mortal affairs",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "fate",
                 "trickery",
@@ -7096,7 +7987,13 @@
                 "5th:": "illusory scene"
             },
             "text": "While the other Queens of the Night are all fallen celestials, Mahathallah was once among the most powerful of the monitors: a psychopomp usher in service of Pharasma. Granted a glimpse of the end of her own existence, Mahathallah fled to the pits of Hell, finding some form of solace in Asmodeus's counsel. Now the Dowager of Illusions, Mahathallah deals in death, fate, and vanity, pulling back the veils of lies that obscure the profound facts of existence. She teaches her followers to seek the truths underlying each falsehood, fomenting arrogance and callousness in them. She also serves as a distant, deliberate advisor to the other Queens of the Night.",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Alglenweis",
@@ -7120,7 +8017,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Strive to perfect an art or craft, protect the monuments of your people, stir others into action",
             "Anathema": "Destroy an artistic creation without providing something in its place, refuse to act if called upon",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "cold",
                 "creation",
@@ -7134,7 +8030,13 @@
                 "5th:": "cone of cold"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Stag Mother of the Forest of Stones",
@@ -7163,7 +8065,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Provide shelter and succor for women and children in need, act as a responsible steward of your environment",
             "Anathema": "Harm a pregnant mother or innocent child, including animals",
-            "Divine Ability": "Constitution or Intelligence",
             "domains": [
                 "family",
                 "healing",
@@ -7177,7 +8078,13 @@
                 "(bull only, appears as stag), 6th:": "flesh to stone"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Sturovenen",
@@ -7201,7 +8108,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Act with conviction and confidence, be a passionate and responsible leader to your people or companions",
             "Anathema": "Command a subordinate to perform a task you're not willing to perform yourself",
-            "Divine Ability": "Dexterity or Charisma",
             "domains": [
                 "air",
                 "confidence",
@@ -7215,7 +8121,13 @@
                 "6th:": "dragon form"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Daikitsu",
@@ -7240,7 +8152,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Ensure the health of crops and vegetation, perfect a craft or trade, leave offerings for foxes, celebrate the turning of the seasons",
             "Anathema": "Mistreat your tools, pass a beggar without giving alms, discriminate against sex workers or the lower class",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "change",
                 "creation",
@@ -7254,7 +8165,13 @@
                 "5th:": "illusory scene"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Fumeiyoshi",
@@ -7278,7 +8195,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Punish those who have good fortune they don't deserve, devour the pleasures of the living, encourage resentment, make graveyards supernaturally unsafe",
             "Anathema": "Pass by food without stealing a bite, allow honor or tradition to prevent you from taking what you want",
-            "Divine Ability": "Constitution or Charisma",
             "domains": [
                 "ambition",
                 "destruction",
@@ -7292,7 +8208,13 @@
                 "7th:": "possession"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "General Susumu",
@@ -7315,7 +8237,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Seek glory in battle, loudly proclaim your victories, protect your possessions and strongholds",
             "Anathema": "Cower from fights, refuse a challenge from an equal, mistreat your weapons, abuse your mount",
-            "Divine Ability": "Strength or Dexterity",
             "domains": [
                 "confidence",
                 "destruction",
@@ -7329,7 +8250,13 @@
                 "3rd:": "wall of wind"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Hei Feng",
@@ -7355,7 +8282,6 @@
             "Edicts": "follow your passions, make token attempts to apologize to those you have wronged, respect the power of the sea and sky, encourage flashy entertainment",
             "Anathema": "fake friendship with those you despise, disrespect Hei Feng or Hei Feng's estranged wife Lady Jingxi, ignore an affront to you or Hei Feng",
             "Areas of Concern": "sea, storms, tengu, sailors",
-            "Divine Ability": "Constitution or Charisma",
             "divinterSource": "Gods & Magic - Web Supplement pg. 7",
             "Minor Boon": "The Heavenly Court's most boastful deity ensures your boasts hit home. Once, when you fail an Intimidation check, you critically succeed instead. Hei Feng grants this boon capriciously based on his mood, sometimes even for trivial or inconsequential boasts, and he sometimes grants it for other skill checks related to boasts.",
             "Moderate Boon": "Fair winds and currents speed your passage. Any vessel you use to travel over the sea gains a +10-foot status bonus to its Speeds.",
@@ -7379,7 +8305,13 @@
                 "6th:": "chain lightning"
             },
             "text": "Hei Feng, the tengu god of storms, is as unpredictable as the sea, as destructive as a hurricane, and, more often than not, as drunk and foulmouthed as the sailors who pray to him. Impulsive and passionate, his heart moves between joy, sorrow, and anger in the time it takes him to finish his cup, though whatever his mood, he rarely feels it lightly. He may be so moved by a fisher's prayer that he blesses her with a catch large enough to feed her village, while later unleashing torrential waves against that same village for a slight. This unpredictability leads the rest of the Heavenly Court to regard him as troublesome, and mortals to view him with wary respect.",
-            "divinterDesc": "The Duke of Thunder's intercessions are seen more commonly than other deities' because of the god's closeness to mortals, but also because of his tendency to dispense both boons and curses while in the depths of his drink."
+            "divinterDesc": "The Duke of Thunder's intercessions are seen more commonly than other deities' because of the god's closeness to mortals, but also because of his tendency to dispense both boons and curses while in the depths of his drink.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Kofusachi",
@@ -7402,7 +8334,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Support local businesses, bring prosperity to your community, sample life's pleasures",
             "Anathema": "Become tied to one location, judge another based on sexual desires or gender roles",
-            "Divine Ability": "Dexterity or Constitution",
             "domains": [
                 "luck",
                 "passion",
@@ -7416,7 +8347,13 @@
                 "8th:": "uncontrollable dance"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Lady Jingxi",
@@ -7439,7 +8376,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Create art with words, master the written language, display the soft beauty of natural colors",
             "Anathema": "Destroy a natural plum tree, drink excessive amounts of alcohol, act rude or boorish",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "creation",
                 "glyph",
@@ -7453,7 +8389,13 @@
                 "5th:": "chromatic wall"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Lady Nanbyo",
@@ -7476,7 +8418,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Revel in destruction, make natural disasters worse, allow natural disasters take their due",
             "Anathema": "Allow a natural disaster to completely destroy a community or leave a group with no survivors",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "destruction",
                 "fire",
@@ -7490,7 +8431,13 @@
                 "6th:": "dragon form"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Lao Shu Po",
@@ -7515,7 +8462,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Work quietly toward your goals in the shadows, steal what you need, keep an ear among the ignored and downtrodden",
             "Anathema": "Work honestly for something you could steal instead, risk too much for another creature",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "darkness",
                 "luck",
@@ -7529,7 +8475,13 @@
                 "3rd:": "nondetection"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Nalinivati",
@@ -7556,7 +8508,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Seek out magic and use it, use poison, heal poisons, bear or adopt children, raise snakes",
             "Anathema": "Kill a harmless snake or swan, spurn friends due to jealousy or romantic competition, betray your offspring, separate lovers",
-            "Divine Ability": "Wisdom or Charisma",
             "domains": [
                 "glyph",
                 "magic",
@@ -7576,7 +8527,13 @@
                 "9th:": "storm of vengeance"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Wisdom",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Qi Zhong",
@@ -7601,7 +8558,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Teach knowledge to others, relieve suffering despite personal difficulty, heal sickness and injuries",
             "Anathema": "Deal lethal damage to another creature (unless as part of a necessary medical treatment)",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "healing",
                 "knowledge",
@@ -7615,7 +8571,13 @@
                 "4th:": "resilient sphere"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Shizuru",
@@ -7640,7 +8602,6 @@
             "Edicts": "practice with a weapon every day, honor your ancestors, protect nature and society from corruption and destruction",
             "Anathema": "abandon a companion in need, dishonor yourself, parlay with truce breakers, separate lovers",
             "Areas of Concern": "ancestors, honor, the sun, and swordplay",
-            "Divine Ability": "Strength or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 9",
             "Minor Boon": "Your attacks help eradicate darkness. When you successfully Strike a foe, your weapon glows with bright light out to 60 feet for 1 minute. This is a light effect with a counteract level equal to half your level rounded up.",
             "Moderate Boon": "Shizuru's light flows through your blade. Your weapons and unarmed attacks deal an additional 1d6 fire damage or 1d6 good damage; you choose each time you make an attack.",
@@ -7663,7 +8624,13 @@
                 "5th:": "summon dragon"
             },
             "text": "The Empress of Heaven is worshipped across all of Tian Xia by people of all walks of life, from commoner to lord, farmer to samurai, human to dragon. She is revered as the ruler of the Tian pantheon, respected as the finest samurai in Heaven or Golarion, and honored as the patron of nature and emperors alike. Perhaps the most famous tale about her is that of Shizuru and her lover Tsukiyo, the moon god. After Tsukiyo was slain by his brother Fumeiyoshi in a fit of jealousy, Shizuru brought the moon god back to life with the aid of Qi Zhong, the god of medicine. Sadly, Tsukiyo was deeply affected by his experience with death, and though he and Shizuru still love each other, the event created a rift between them. Even so, on the days of an eclipse, they embrace as one.",
-            "divinterDesc": "The Empress of Heaven wastes little time acting coy about her favor. Her boons are often accompanied by beams of sunlight or calligraphic symbols, while her wrath is often signaled by the cracking of precious items and armor."
+            "divinterDesc": "The Empress of Heaven wastes little time acting coy about her favor. Her boons are often accompanied by beams of sunlight or calligraphic symbols, while her wrath is often signaled by the cracking of precious items and armor.",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Sun Wukong",
@@ -7688,7 +8655,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Live life freely, drink, play pranks",
             "Anathema": "Refuse a reasonable bet or duel, let social pressure change your behavior",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "indulgence",
                 "might",
@@ -7702,7 +8668,13 @@
                 "4th:": "creation"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Tsukiyo",
@@ -7729,7 +8701,6 @@
             "Edicts": "provide aid and counsel without judgment to those who seek help, help the dead find their rest, amplify or help speak for the powerless and demonized",
             "Anathema": "harm another out of envy, force aid on those who do not want it, inflict harmful mental effects on others as punishment",
             "Areas of Concern": "jade, the moon, spirits",
-            "Divine Ability": "Constitution or Intelligence",
             "divinterSource": "Gods & Magic - Web Supplement pg. 9",
             "Minor Boon": "Tsukiyo's simplest show of gratitude is a gift of clarity. Once, when you roll a failure on a saving throw against a mental effect, you get a critical success instead. Tsukiyo typically grants this boon against a particularly consequential mental effect.",
             "Moderate Boon": "Tsukiyo watches over you and guards your sleep. You are guaranteed a peaceful night's rest no matter what conditions you are sleeping in. Even nightmare and similar abilities can't disrupt your sleep unless they come from a deity, artifact, or similarly powerful source.",
@@ -7752,7 +8723,13 @@
                 "5th:": "hallucination"
             },
             "text": "The surface of Golarion's moon is marred with a great scar, and the people of Tian Xia say this is where Tsukiyo, the Prince of the Moon, was struck down by his envious brother Fumeiyoshi. When his lover Shizuru found him the next morning, her tears mixed with his blood to create the first pieces of jade. Shizuru brought him to Qi Zhong, the god of medicine, who resurrected him; but his experience on the other side changed him from a boisterous and carefree soul to a thoughtful and temperamental one. He now sees the world differently from most-something that has strained his relationships and made it difficult for him to relate to others, but has also allowed him to offer his understanding and quiet comfort to those who are lost, demonized, or misunderstood.",
-            "divinterDesc": "Ever mercurial, the Prince of the Moon gives his blessings rarely and somewhat spontaneously. An understanding soul, he is as slow to curse as he is to bless."
+            "divinterDesc": "Ever mercurial, the Prince of the Moon gives his blessings rarely and somewhat spontaneously. An understanding soul, he is as slow to curse as he is to bless.",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Yaezhing",
@@ -7775,7 +8752,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Commit assassinations for hire, strike unseen, carry out punishment for convicted criminals",
             "Anathema": "Show mercy to a target, take credit for your assassinations, refuse to punish a lawfully convicted criminal",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "death",
                 "duty",
@@ -7789,7 +8765,13 @@
                 "6th:": "mislead"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Yamatsumi",
@@ -7815,7 +8797,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Strive to be self-sufficient, respect nature, test yourself against the elements",
             "Anathema": "Become reliant on civilization, destroy something without creating or growing something in its place",
-            "Divine Ability": "Strength or Wisdom",
             "domains": [
                 "cold",
                 "earth",
@@ -7829,7 +8810,13 @@
                 "7th:": "volcanic eruption"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Arundhat",
@@ -7854,7 +8841,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Practice herbalism, tend to sacred flowers, offer appropriate flowers to other divinities",
             "Anathema": "Dispose of waste near flowers, harvest flowers without offering the proper prayers, dispose of withered flowers improperly",
-            "Divine Ability": "Intelligence or Wisdom",
             "domains": [
                 "healing",
                 "magic",
@@ -7868,7 +8854,13 @@
                 "4th:": "speak with plants"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ashukharma",
@@ -7893,7 +8885,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Hinder travel, create and enforce physical and emotional boundaries, build defensive earthworks",
             "Anathema": "Destroy a natural barrier, pursue a personal relationship after being refused, betray a lover",
-            "Divine Ability": "Constitution or Intelligence",
             "domains": [
                 "earth",
                 "might",
@@ -7907,7 +8898,13 @@
                 "5th:": "wall of stone"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Chamidu",
@@ -7932,7 +8929,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Destroy aberrant creatures and fiends, live free of social or materialistic chains, cause destruction when angered",
             "Anathema": "Harm a child, pollute the wilds, refuse to treat an illness",
-            "Divine Ability": "Strength or Constitution",
             "domains": [
                 "healing",
                 "lightning",
@@ -7946,7 +8942,13 @@
                 "5th:": "moon frenzy"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Constitution"
+                ]
+            ]
         },
         {
             "name": "Dhalavei",
@@ -7970,7 +8972,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Infiltrate righteous organizations and governments, destroy trust, perform human sacrifices",
             "Anathema": "Betray a fellow servant of Dhalavei, harm those under Dhalavei's protection",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "destruction",
                 "knowledge",
@@ -7984,7 +8985,13 @@
                 "6th:": "mislead"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Diomazul",
@@ -8008,7 +9015,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Remain celibate and detached from worldly pleasures, meditate, utterly destroy your enemies, erase all traces of defeated foes",
             "Anathema": "Provoke a fight, give mercy to anyone who provokes a fight with you",
-            "Divine Ability": "Strength or Dexterity",
             "domains": [
                 "destruction",
                 "earth",
@@ -8022,7 +9028,13 @@
                 "4th:": "weapon storm"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Dexterity"
+                ]
+            ]
         },
         {
             "name": "Gruhastha",
@@ -8046,7 +9058,6 @@
             "Edicts": "work toward collective transcendence, expose and root out malicious lies, challenge oppression through education, protect knowledge, seek truth",
             "Anathema": "deny a sincere student education, destroy knowledge, disrespect the traditions of those around you, willfully spread ignorance or wrong information",
             "Areas of Concern": "enlightenment, the Vudrani holy book",
-            "Divine Ability": "Intelligence or Wisdom",
             "divinterSource": "Gods & Magic - Web Supplement pg. 6",
             "Minor Boon": "Books fall open to insightful passages, and memories spring to mind when they are most needed. Once, when you fail a check to Recall Knowledge, you critically succeed instead. Gruhastha typically grants this boon for an extremely consequential attempt to Recall Knowledge, particularly when misinformation would have dire consequences.",
             "Moderate Boon": "The Keeper speeds your path toward learning new talents. You become permanently trained in two additional skills of your choice. Additionally, you can select a skill you are already trained in and permanently increase your proficiency rank in that skill, following the usual rules for skill increases.",
@@ -8070,7 +9081,13 @@
                 "3rd:": "hypercognition"
             },
             "text": "Gruhastha the Keeper is a deity of understanding, peace, and the collective pursuit of enlightenment. The once-mortal nephew of Irori is believed to have ascended to godhood himself after creating the holy book *Azvadeva Pujila*, fully embodying all divine wisdom within the text. Originating in Vudra, the Keeper's faith has slowly gained popularity in the Inner Sea region, particularly in Jalmeray, where Irori already has a wide following. Gruhastha manifests as a human man with an idealized form, augmented with wings of red and green plumage and a golden mandala as a halo.",
-            "divinterDesc": "The Keeper encourages the search for knowledge and rewards those that travel their personal path of enlightenment, but he punishes those who interrupt these journeys or destroy knowledge."
+            "divinterDesc": "The Keeper encourages the search for knowledge and rewards those that travel their personal path of enlightenment, but he punishes those who interrupt these journeys or destroy knowledge.",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Lahkgya",
@@ -8093,7 +9110,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Steal luxuries for yourself, destroy property for fun, demand bribes to spare creatures from your torments",
             "Anathema": "Work honestly for something you could steal instead, kill a monkey",
-            "Divine Ability": "Dexterity or Intelligence",
             "domains": [
                 "indulgence",
                 "nature",
@@ -8107,7 +9123,13 @@
                 "4th:": "confusion"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Intelligence"
+                ]
+            ]
         },
         {
             "name": "Likha",
@@ -8133,7 +9155,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Tell history to others, sponsor or perform in plays and recitals, adapt ancient works into modern language",
             "Anathema": "Begin a performance or tale without first inviting the gods to watch, act out a death on stage",
-            "Divine Ability": "Intelligence or Charisma",
             "domains": [
                 "creation",
                 "knowledge",
@@ -8147,7 +9168,13 @@
                 "5th:": "illusory scene"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
         },
         {
             "name": "Matravash",
@@ -8171,7 +9198,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Aid the persecuted, accommodate and facilitate others, practice contemplation and restraint",
             "Anathema": "Destroy lotus fields, interfere with the flow of the Matra river, pollute clean water, reveal the location of nonevil fugitives",
-            "Divine Ability": "Constitution or Wisdom",
             "domains": [
                 "cities",
                 "nature",
@@ -8185,7 +9211,13 @@
                 "4th:": "speak with plants"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Ragdya",
@@ -8210,7 +9242,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Seek enlightenment through worldly experience, create humor in life, use harmless pranks to teach others",
             "Anathema": "Make a joke out of someone's suffering, own a slave, discriminate based on social status",
-            "Divine Ability": "Dexterity or Wisdom",
             "domains": [
                 "air",
                 "confidence",
@@ -8224,7 +9255,13 @@
                 "4th:": "gaseous form"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Dexterity",
+                    "Wisdom"
+                ]
+            ]
         },
         {
             "name": "Raumya",
@@ -8250,7 +9287,6 @@
             "source": "Gods & Magic pg. 132",
             "Edicts": "Improve yourself with music and literature, take what you want, seek power above others",
             "Anathema": "Abuse a loyal subject, harm or kill a non-combatant",
-            "Divine Ability": "Strength or Charisma",
             "domains": [
                 "confidence",
                 "knowledge",
@@ -8264,7 +9300,231 @@
                 "4th:": "weapon storm"
             },
             "text": "*Nethys Note: no description has been provided of this deity*",
-            "divinterDesc": ""
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Strength",
+                    "Charisma"
+                ]
+            ]
+        },
+        {
+            "name": "Atheism",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=21",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "all"
+            ],
+            "source": "Core Rulebook pg. 440",
+            "Edicts": "none",
+            "Anathema": "none",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "In a world where the gods demonstrably exist, few people uphold a strictly atheistic or agnostic worldview; that is, a belief that there are no gods, or that the existence of gods is unknowable. However, a good number of people choose not to worship any deities whatsoever. Many do so because of the value they place on freedom-not being beholden to a deity means no limitations, no censure, no anathema, and no strictures. While this decision might sound amoral to some, for atheists, it can be motivated by a desire for autonomy and the right to choose one's own fate.",
+            "divinterDesc": "",
+            "divAbility": []
+        },
+        {
+            "name": "Green Faith",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=22",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "NG",
+                "LN",
+                "N",
+                "CN",
+                "NE"
+            ],
+            "source": "Gods & Magic pg. 97",
+            "Edicts": "guide civilization to grow in harmony with nature, live sustainably and according to natural cycles, preserve areas of natural wilderness, protect the balance of nature, protect endangered species",
+            "Anathema": "cause damage to natural settings, kill animals for reasons other than self-defense or sustenance, remove an element or indigenous species from a natural area, encourage imbalance in nature, allow abuse of natural resources",
+            "Areas of Concern": "veneration of the natural world",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "While the Green Faith is practiced differently from one believer to another, especially across its various orders, its adherents share a universal reverence for the natural world and a commitment to preserving it. While each order's practitioners may be drawn to a particular element, season, creature, or natural occurrence, all followers respect the sanctity and importance of every aspect of nature. Many cycles have passed since the Green Faith's fabled founders contended over which expression of natural power was supreme. Just as the legend speaks of their ultimate unity, those who now follow the Green Faith and view nature as sacred understand the interconnectedness of all beings, recognizing that harmony is possible only through balance, and that the cycles of nature are both delicate and infinite. Advocates of the Green Faith therefore fall into a neutral alignment, for they understand that by naming one thing, its opposite is also created; they walk the path of balance between death and rebirth, light and shadow, growth and decay.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Wisdom"
+                ]
+            ]
+        },
+        {
+            "name": "Prophecies of Kalistrade",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=23",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "LG",
+                "LN",
+                "LE"
+            ],
+            "source": "Gods & Magic pg. 99",
+            "Edicts": "accumulate personal wealth, seek enlightenment through purity of self, foster and aid mercantile pursuits, welcome newcomers regardless of gender or ancestry",
+            "Anathema": "spend money frivolously; offer money to those who don't deserve wealth; overindulge in physical pleasures, food, or drink; give charity to others",
+            "Areas of Concern": "trade, wealth, self-denial, stability",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "The secular prophecies of Kalistrade are famously centered on a single principle: amassing personal wealth both in search of and as evidence of personal enlightenment. The prophets of Kalistrade, often referred to as Kalistocrats, believe that achieving purity of body, mind, and spirit will lead to financial success, and thus they avoid certain foods and eschew contact with most persons and objects as impure. To avoid contamination and contact with nonbelievers they wear long, white gloves, and they wear distinctive, all-white clothing to represent their purity-often incorporating their symbol, a circle inside a triangle that is itself inscribed in a larger circle.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Charisma"
+                ]
+            ]
+        },
+        {
+            "name": "Whispering Way",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=24",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "LE",
+                "NE",
+                "CE"
+            ],
+            "source": "Core Rulebook pg. 441",
+            "Edicts": "seek methods to become undead (a lich if possible), oppose those who seek to destroy undead, protect necromantic secrets, serve the Whispering Tyrant",
+            "Anathema": "destroy necromantic texts (unless they reveal secrets of the Whispering Way), teach others of the Whispering Way other than by whispering, use positive energy to harm undead",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "These cultists believe undeath is the truest form of existence, and life is meant to be spent in preparation for transition to a more glorious unlife after death.",
+            "divinterDesc": "",
+            "divAbility": []
+        },
+        {
+            "name": "Esoteric Order of the Palatine Eye",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=199",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "LG",
+                "LN",
+                "N",
+                "LE"
+            ],
+            "source": "Gods & Magic pg. 94",
+            "Edicts": "seek out wisdom of ancient cultures (particularly Ancient Osirion), provide succor to scholars, honor the rites of the order",
+            "Anathema": "reveal the order's secrets to those outside the organization (or even to insufficiently ranked members), destroy rare or ancient lore",
+            "Areas of Concern": "history, occultism, secret lore",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "Based in Ustalav but active in aristocratic salons and cloistered academies across Avistan and Garund, the Esoteric Order of the Palatine Eye is a mystic order of occultist-nobles who seek philosophical self-awareness and mastery of celestial truths. The order was founded in 3988 AR when the gentleman-explorer Aldus Canter returned from the Osirian desert where he had been lost for 3 years. Aldus spoke of meeting a cult following a desiccated angel named Tabris. Tabris revealed the secret history of the multiverse and tasked Aldus with acting as a messenger of mystic secrets. Upon his return, Aldus gathered a coterie of his fellow Ustalavic nobles eager to plumb these secrets. His message was far from clear, however, consisting of garbled and coded texts in an untidy medley of Osirian mysticism, Pharasmin rites, and Varisian occult lore. Scouring Aldus's texts-both those brought from Osirion and his many annotations and reinterpretations penned thereafter-has been the order's primary activity for centuries, even before the increasingly erratic Aldus disappeared in 4028 AR. The Esoteric Order's meticulous research has produced occult secrets and mystical rites known nowhere else on Golarion and hints at further secret lore for the enlightened. The order's greatest accomplishment, however, was averting a doomsday few on Golarion will ever realize was imminent: in 4718 AR, the order's greatest heroes prevented the planet Aucturn from devouring Golarion.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
+        },
+        {
+            "name": "God Calling",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=200",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                ""
+            ],
+            "source": "Gods & Magic pg. 95",
+            "Edicts": "The gods of Sarkoris have very few shared edicts, but several are often prominently shared amongst them: protect your clan and your people, educate the clan's children's in the traditions and histories of the clan's god, and carefully record the name and image of each new god when they first appear so that they are not forgotten and can continue to watch over the people.",
+            "Anathema": "There is only one anathema universally enforced by the gods of Sarkoris: make no deals or bargains with demons, as the advent of the Worldwound led to the destruction of many clans and the loss of many gods, some of whom may never be seen again.",
+            "Areas of Concern": "Each god has their own particular inclinations and interests, typically informed by the predominant attitudes and beliefs of their clan.",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "The ancient art of god calling was once the predominant religious practice in Sarkoris, long before the Worldwound erupted and demons drove most of the native Sarkorians from their homelands. This art, one part magical theory and one part religion, allows certain Sarkorians to summon unusual and unique beings from the Great Beyond who protect their clans and guide their people. These creatures are typically referred to as gods by those who revere them, and they continue to return and guide their people generation after generation, so long as someone trained by a previous god caller or otherwise educated in the practice of communing with a particular god is alive to form a tether to the Material Plane so that the god can manifest. These god callers may have unique titles or names among the people of their clan, and such monikers differ from clan to clan, but most of the clans of Sarkoris are able to distinguish a god caller by their unique dress or glyph that ties the caller to their god.",
+            "divinterDesc": "",
+            "divAbility": []
+        },
+        {
+            "name": "Laws of Mortality",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=201",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "LG",
+                "NG",
+                "LN",
+                "N",
+                "LE",
+                "NE"
+            ],
+            "source": "Gods & Magic pg. 97",
+            "Edicts": "challenge religious power and the spread of religion, expose and eradicate hidden worship, provide a peaceful and autonomous society in which the people are cared for through social infrastructure",
+            "Anathema": "worship or swear an oath by a deity or religion, solicit or receive divine or religious aid, take a side in conflicts between religions",
+            "Areas of Concern": "mortal affairs, peace, self-rule",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "The Laws of Mortality originated in the Garundi nation of Rahadoum as a response to the Oath Wars, a series of internecine conflicts that were tearing the nation's society apart. The fundamental principle behind the Laws is a relatively simple assertion that deific aid-even the best intentioned-ultimately comes at too high a price. The slaughter of fellow mortals for the glory of distant, unfathomable beings is not something that should be permitted within a society. Instead, mortal beings must shape their own fate, aware of their own limitations, trusting in their reliance upon one another and their shared values rather than divine intervention and guidance. This philosophy is summed up in the primary tenet of the Laws of Mortality: Let no mortal be beholden to a god.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Constitution",
+                    "Intelligence"
+                ]
+            ]
+        },
+        {
+            "name": "Sangpotshi",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=202",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                "LG",
+                "NG",
+                "LN",
+                "N",
+                "LE"
+            ],
+            "source": "Gods & Magic pg. 99",
+            "Edicts": "live selflessly; heed the wisdom of the learned, the wise, and those in stations of authority",
+            "Anathema": "needlessly break significant traditions, actively interfere with the perfection efforts of another soul or allow others to do so",
+            "Areas of Concern": "fate, karma, and reincarnation",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "The philosophy of Sangpotshi, also known as the River of Life, centers around concepts of fate, karma, and cyclic reincarnation. Adherents believe each soul is judged upon its actions in life, and these actions determine its station when it returns to the living world. This cycle repeats until the soul reaches its perfected form through the accrual of experience and wisdom, whereupon it passes on to Pharasma's court and the afterlife to come.",
+            "divinterDesc": "",
+            "divAbility": [
+                [
+                    "Intelligence",
+                    "Wisdom"
+                ]
+            ]
+        },
+        {
+            "name": "Shoanti Animism",
+            "link": "https://2e.aonprd.com/Deities.aspx?ID=203",
+            "PFS": "No PFS Data",
+            "category": "Faiths and Philosophies",
+            "followerAlignments": [
+                ""
+            ],
+            "source": "Gods & Magic pg. 100",
+            "Lyrune-Quah (Moon Clan)": "bat, cave bear, moon, mountain lion, owl, stars",
+            "Shadde-Quah (Axe Clan)": "cliffs, eagle, sea, shark, squid, water elemental",
+            "Shriikirri-Quah (Hawk Clan)": "cloud, falcon, hawk, hippogriff, horse, wind",
+            "Shundar-Quah (Spire Clan)": "avalanche, earth elemental, mountain spire or peak, roc, spirestalker",
+            "Sklar-Quah (Sun Clan)": "aurochs, cindersnake, emberstorm, fire elemental, flames, the sun",
+            "Skoan-Quah (Skull Clan)": "ancestors, earth elemental, giant scarab beetle, vulture, will-o'-wisp, wolf",
+            "Tamiir-Quah (Wind Clan)": "air elemental, cloud, griffon, roc, storm, wind According to their own tradition, Shoanti have lived in the northwestern lands of Avistan since long before colonizers fractured the Varisians' homeland. Yet the Shoanti people still maintain their independence and traditional way of life in areas across Varisia, particularly on the Storval Plateau. Shoanti animism is rooted in a deep connection to the land. Shoanti see the earth not merely as a metaphorical parent, but as a conscious entity whose constant support is necessary for the survival of all life upon it-animal and vegetable alike. Their traditions emphasize connection and the reciprocal way in which the land provides for those who take care of it. The life force of the land serves as the source of Shoanti power and insight, rather than the otherworldly spiritual essence of the Great Beyond common to clerics. This life force is the birth of instinct and faith, and thus it sends omens to indicate future events, warning those with the wisdom to read the signs. Thus most Shoanti hold a profound reverence for natural phenomena as a manifestation of the will of the earth.",
+            "domains": [],
+            "altDomains": [],
+            "clericSpells": {},
+            "text": "Most Shoanti belong to one of seven quahs, or clans, each with specific lands, notable strengths, and unique spiritual perspectives. Traditionally, each Shoanti undergoes a rite of passage into adulthood, during which time their particular totem manifests, and a Shoanti's first tattoo is an homage to that totem. The quahs and their most common totems are listed below:",
+            "divinterDesc": "",
+            "divAbility": []
         }
     ]
 }


### PR DESCRIPTION
Faiths and philosophies have fewer attributes than deities.  Shoanti quahs are automatically their own attributes, which seems reasonable enough; it lets things which pull from JSON handle quahs separately if they want.